### PR TITLE
Add build to binder GHA

### DIFF
--- a/.github/workflows/build-to-binder.yml
+++ b/.github/workflows/build-to-binder.yml
@@ -1,0 +1,14 @@
+name: Build to Binder
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build and cache on mybinder.org
+      uses: jupyterhub/repo2docker-action@master
+      with:
+        NO_PUSH: true
+        MYBINDERORG_TAG: ${{ github.event.ref }}


### PR DESCRIPTION
This will make it so no one has to wait for binder builds. The image will just be built whenever there is a push to main