### PR TITLE
Restructure docs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -37,22 +37,34 @@ website:
       - veda-apis.qmd
       - section: example-notebooks/index.qmd
         contents:
-          - section: Basic
-            contents:
-              - example-notebooks/list-collections.ipynb
-              - example-notebooks/open-and-plot.ipynb
-              - example-notebooks/timeseries-rioxarray-stackstac.ipynb
-              - example-notebooks/visualize-zarr.ipynb
-              - example-notebooks/visualize-multiple-times.ipynb
-              - example-notebooks/downsample-zarr.ipynb
-              - example-notebooks/intake.ipynb
-              - example-notebooks/wfs.ipynb
-          - section: Using the Raster API
-            contents:
-              - example-notebooks/no2-map-plot.ipynb
-              - example-notebooks/timeseries-stac-api.ipynb
-              - example-notebooks/hls-visualization.ipynb
+          - section: Quickstarts
+            contents: 
+              - section: Accessing the Data Directly
+                contents: 
+                  - example-notebooks/list-collections.ipynb
+                  - example-notebooks/open-and-plot.ipynb
+                  - example-notebooks/timeseries-rioxarray-stackstac.ipynb
+                  - example-notebooks/visualize-zarr.ipynb
+                  - example-notebooks/visualize-multiple-times.ipynb
+                  - example-notebooks/downsample-zarr.ipynb
+                  - example-notebooks/intake.ipynb
+                  - example-notebooks/wfs.ipynb
+              - section: Using the Raster API
+                contents:
+                  - example-notebooks/no2-map-plot.ipynb
+                  - example-notebooks/timeseries-stac-api.ipynb
+                  - example-notebooks/hls-visualization.ipynb
+          - section: Tutorials
+            contents: 
               - example-notebooks/gif-generation.ipynb
+          - section: Datasets
+            contents:
+              - example-notebooks/ocean-npp-timeseries-analysis.ipynb
+              - example-notebooks/nceo-biomass-statistics.ipynb
+
+
+
+
       - external-resources.qmd
 
 format:
@@ -64,6 +76,7 @@ format:
     code-overflow: wrap
     css: styles.css
     toc: true
+    toc-depth: 3
 
 
 filters:

--- a/example-notebooks/index.qmd
+++ b/example-notebooks/index.qmd
@@ -3,26 +3,25 @@ title: Usage Examples
 ---
 
 ## Getting started
+The example notebooks are divided into three sections: 
 
-The example notebooks are divided into three secions: 
-* Quickstarts: Notebooks to get you started quickly and help you come more familiar with cloud-native geospatial technologies.
-* Tutorials: Longer notebooks that walk through more advanced use cases and examples.
-* Datasets: Notebooks that showcase a particular VEDA dataset and walk through applied geospatial analyses.
+- **Quickstarts**: Notebooks to get you started quickly and help you become more familiar with cloud-native geospatial technologies.
+- **Tutorials**: Longer notebooks that walk through more advanced use cases and examples.
+- **Datasets**: Notebooks that showcase a particular VEDA dataset and walk through an applied geospatial analyses.
 
 ## Choosing the right data access route for your needs
+The Quickstarts examples are further divided into two sections, which you can choose from depending on your data needs:
 
-The Quickstarts examples are further divided into two sections, which you can choose from depending on your data needs: 
-* Accessing the Data Directly: For when you want to do specific data analysis procedures or want to access the raw data. In this case, permissions are required to access the data (i.e., must be run on VEDA JupyterHub) and computation happens within the user's instance (i.e., the user needs to think about instance size). This approach is suitable for use within notebooks. All of these notebook examples provided require access to VEDA JupyterHub. 
-* Using the Raster API: For when you want to show outputs to other people or do standard processing. No permissions required (i.e., notebooks can be run on `mybinder`). Additionally, the computation happens somehwere else (i.e., user does not have to think about instance size). Lastly, this approach is suitable for use within notebooks as well as web application frontends (e.g., like dataset discoveries). These notebook examples can be run on both VEDA JupyterHub, as well as outside of the Hub (see instructions below) and within `mybinder`.
+- **Accessing the Data Directly**: For when you want to access the raw data (e.g., to do a specific analysis). In this case, permissions are required to access the data (i.e., must be run on VEDA JupyterHub) and computation happens within the user's instance (i.e., the user needs to think about instance size). This approach is suitable for use within notebooks. All examples provided in this section require VEDA JupyterHub access to run. 
+
+- **Using the Raster API**: For when you want to show outputs to other people or do standard processing. No permissions required (i.e., notebooks can be run on `mybinder`). Additionally, the computation happens somehwere else (i.e., user does not have to think about instance size). Lastly, this approach is suitable for use within notebooks as well as web application frontends (e.g., like dataset discoveries). These notebook examples can be run on both VEDA JupyterHub, as well as outside of the Hub (see instructions below) and within `mybinder`.
 
 
-## Run
+## How to run
 
-Every notebook contains information about how to run it. Some can run on [mybinder](https://mybinder.org/) and all can run on the VEDA JupyterHub.
+Every notebook contains information about how to run it. Some can run on [mybinder](https://mybinder.org/) and all can run on the VEDA JupyterHub. See [VEDA Analytics JupyterHub Access](https://nasa-impact.github.io/veda-docs/veda-jh-access.html) for information about how to gain access.
 
-See [VEDA Analytics JupyterHub Access](https://nasa-impact.github.io/veda-docs/veda-jh-access.html) for information about how to gain access.
-
-### Run outside the Hub
+### Running outside of VEDA JupyterHub
 
 To run the notebooks locally, you can use a python [virtual environment](https://docs.python.org/3/library/venv.html) and [jupyter](https://jupyter.org/).
 
@@ -42,7 +41,7 @@ If the notebook needs access to protected data on S3, you will need to specifica
 
 Contribution to VEDA's documentation is always welcome. In order to share your notebook on VEDA's JupyterHub, you'll have to generate a link to allow for that functionality. You can find more details in the instructions below.
 
-## Generate a "Run on VEDA" link
+### Generate a "Run on VEDA" link
 
 We use [`nbgitpuller`](https://hub.jupyter.org/nbgitpuller/) links to open the VEDA JupyterHub with a particular notebook pulled in. These links have the form: `https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/example-notebooks/open-and-plot.ipynb&branch=main`
 

--- a/example-notebooks/index.qmd
+++ b/example-notebooks/index.qmd
@@ -1,12 +1,26 @@
 ---
-title: Example Notebooks
+title: Usage Examples
 ---
+
+## Getting started
+
+The example notebooks are divided into three secions: 
+* Quickstarts: Notebooks to get you started quickly and help you come more familiar with cloud-native geospatial technologies.
+* Tutorials: Longer notebooks that walk through more advanced use cases and examples.
+* Datasets: Notebooks that showcase a particular VEDA dataset and walk through applied geospatial analyses.
+
+## Choosing the right data access route for your needs
+
+The Quickstarts examples are further divided into two sections, which you can choose from depending on your data needs: 
+* Accessing the Data Directly: For when you want to do specific data analysis procedures or want to access the raw data. In this case, permissions are required to access the data (i.e., must be run on VEDA JupyterHub) and computation happens within the user's instance (i.e., the user needs to think about instance size). This approach is suitable for use within notebooks. All of these notebook examples provided require access to VEDA JupyterHub. 
+* Using the Raster API: For when you want to show outputs to other people or do standard processing. No permissions required (i.e., notebooks can be run on `mybinder`). Additionally, the computation happens somehwere else (i.e., user does not have to think about instance size). Lastly, this approach is suitable for use within notebooks as well as web application frontends (e.g., like dataset discoveries). These notebook examples can be run on both VEDA JupyterHub, as well as outside of the Hub (see instructions below) and within `mybinder`.
+
 
 ## Run
 
-Every notebook contains information about how to run it. Some can run on [mybinder]https://mybinder.org/) and all can run on the VEDA JupyterHub.
+Every notebook contains information about how to run it. Some can run on [mybinder](https://mybinder.org/) and all can run on the VEDA JupyterHub.
 
-See (VEDA Analytics JupyterHub Access)[https://nasa-impact.github.io/veda-docs/veda-jh-access.html] for information about how to gain access.
+See [VEDA Analytics JupyterHub Access](https://nasa-impact.github.io/veda-docs/veda-jh-access.html) for information about how to gain access.
 
 ### Run outside the Hub
 
@@ -23,6 +37,10 @@ jupyter notebook
 ```
 
 If the notebook needs access to protected data on S3, you will need to specifically get access. Please request access by emailing aimee@developmentseed.org or alexandra@developmentseed.org and providing your affiliation, interest in or expected use of the dataset and an AWS IAM role or user Amazon Resource Name (ARN).
+
+## Contributing to VEDA 
+
+Contribution to VEDA's documentation is always welcome. In order to share your notebook on VEDA's JupyterHub, you'll have to generate a link to allow for that functionality. You can find more details in the instructions below.
 
 ## Generate a "Run on VEDA" link
 

--- a/external-resources.qmd
+++ b/external-resources.qmd
@@ -1,9 +1,9 @@
 ---
-title: "External Resources"
+title: "Geospatial Cloud Computing and Analysis"
 subtitle: "Learn more about tools and practice open source geospatial data science - a list of external resources to get you started"
 ---
 
-This list is intended for (aspiring) scientists who want to get started with cloud-based, collaborative, open geospatial data analysis, or those looking to refresh their knowledge. It is by no means complete, but contains pointers to more elaborate resources. We anticipate this list to evolve as our platform and use cases evolve. Suggestions for additional resources or topics are highly welcome.
+This list is intended for scientists who want to get started with cloud-based, collaborative, open geospatial data analysis, or those looking to refresh their knowledge. It is by no means complete, but contains pointers to more elaborate resources. We anticipate this list to evolve as our platform and use cases evolve. Suggestions for additional resources or topics are highly welcome.
 
 ## Master the basic workflow tools
 * [Git - for managing code versions](https://docs.github.com/en/get-started/quickstart/github-flow)

--- a/veda-apis.qmd
+++ b/veda-apis.qmd
@@ -1,4 +1,4 @@
-# VEDA STAC API and Browser {.unnumbered}
+# VEDA APIs {.unnumbered}
 
 The VEDA API source code is currently stored in a private repository: [veda-backend](https://github.com/NASA-IMPACT/veda-backend), but is based off [eoAPI](https://github.com/developmentseed/eoAPI).
 

--- a/veda-jh-access.qmd
+++ b/veda-jh-access.qmd
@@ -1,4 +1,4 @@
-# VEDA Analytics JupyterHub Access {#veda-jh-access}
+# VEDA Analytics Platform and JupyterHub {#veda-jh-access}
 
 Explore VEDA datasets and stories using a JupyterHub notebook environment on [https://nasa-veda.2i2c.cloud/](https://nasa-veda.2i2c.cloud/)
 


### PR DESCRIPTION
In this PR, I have used the discussion on this [ticket](https://github.com/NASA-IMPACT/veda-docs/issues/31) to inform
* revision of page titles as described in the ticket linked above 
* created new subsets for `Usage Examples` which include: `Quickstarts`, `Tutorials`, and `Datasets`
* added text to `Usage Examples` which includes describing the two routes to accessing data, as well as creating subsections for the `Quickstarts` folder: _Accessing data directly_ (formerly called "Basic"), and _Using the Raster API_ 
* reorganized all notebook examples into the above sections as they were applicable (includes moving GIF formation notebook into `Tutorials` examples, and dataset discovery/geospatial analyses into `Datasets` example. 