### PR TITLE
Volcano SO2 monitoring notebook

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -61,6 +61,8 @@ website:
             contents:
               - example-notebooks/ocean-npp-timeseries-analysis.ipynb
               - example-notebooks/nceo-biomass-statistics.ipynb
+              - example-notebooks/volcano-so2-monitoring.ipynb
+
 
 
 

--- a/example-notebooks/volcano-so2-monitoring.ipynb
+++ b/example-notebooks/volcano-so2-monitoring.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Monitoring Volcanic Sulfur Dioxide Emissions\n",
+    "description: NASA monitors volcanic emissions and its impact on global air quality\n",
+    "author: Kathryn Berger\n",
+    "date: April 4, 2023\n",
+    "execute:\n",
+    "   freeze: true\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Run this notebook\n",
+    "\n",
+    "You can launch this notebook in VEDA JupyterHub by clicking the link below.\n",
+    "\n",
+    "[Launch in VEDA JupyterHub (requires access)](https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/example-notebooks/volcano-so2-monitoring.ipynb&branch=main) \n",
+    "\n",
+    "<details><summary>Learn more</summary>\n",
+    "    \n",
+    "### Inside the Hub\n",
+    "\n",
+    "This notebook was written on the VEDA JupyterHub and as such is designed to be run on a jupyterhub which is associated with an AWS IAM role which has been granted permissions to the VEDA data store via its bucket policy. The instance used provided 16GB of RAM. \n",
+    "\n",
+    "See (VEDA Analytics JupyterHub Access)[https://nasa-impact.github.io/veda-docs/veda-jh-access.html] for information about how to gain access.\n",
+    "\n",
+    "### Outside the Hub\n",
+    "\n",
+    "The data is in a protected bucket. Please request access by emailng aimee@developmentseed.org or alexandra@developmentseed.org and providing your affiliation, interest in or expected use of the dataset and an AWS IAM role or user Amazon Resource Name (ARN). The team will help you configure the cognito client.\n",
+    "\n",
+    "You should then run:\n",
+    "\n",
+    "```\n",
+    "%run -i 'cognito_login.py'\n",
+    "```\n",
+    "    \n",
+    "</details>"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example-notebooks/volcano-so2-monitoring.ipynb
+++ b/example-notebooks/volcano-so2-monitoring.ipynb
@@ -187,59 +187,15 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2005-01-01T00:00:00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Year 2005\n",
-    "print(items[16]['properties']['start_datetime'])"
+    "# to access the year value from each item more easily\n",
+    "items = {item[\"properties\"][\"start_datetime\"][:4]: item for item in items} "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2009-01-01T00:00:00\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Year 2009\n",
-    "print(items[12]['properties']['start_datetime'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2021-01-01T00:00:00\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Year 2021\n",
-    "print(items[0]['properties']['start_datetime'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -271,14 +227,14 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "tile_2005 = requests.get(\n",
-    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[16]['collection']}&item={items[16]['id']}\"\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items['2005']['collection']}&item={items['2005']['id']}\"\n",
     "    \"&assets=cog_default\"\n",
     "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
     "    f\"&rescale={rescaling_factor}\", \n",
@@ -288,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -304,14 +260,14 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "tile_2009 = requests.get(\n",
-    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[12]['collection']}&item={items[12]['id']}\"\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items['2009']['collection']}&item={items['2009']['id']}\"\n",
     "    \"&assets=cog_default\"\n",
     "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
     "    f\"&rescale={rescaling_factor}\", \n",
@@ -321,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -337,19 +293,19 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "tile_2020 = requests.get(\n",
-    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[0]['collection']}&item={items[0]['id']}\"\n",
+    "tile_2021 = requests.get(\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items['2021']['collection']}&item={items['2021']['id']}\"\n",
     "    \"&assets=cog_default\"\n",
     "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
     "    f\"&rescale={rescaling_factor}\", \n",
     ").json()\n",
-    "tile_2020"
+    "tile_2021"
    ]
   },
   {
@@ -368,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +357,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_773b099f2ed05e628b7cb622e561b18d {\n",
+       "                #map_c448b8157de9cc32ae922f6b3904cc62 {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -415,14 +371,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_773b099f2ed05e628b7cb622e561b18d&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_c448b8157de9cc32ae922f6b3904cc62&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_773b099f2ed05e628b7cb622e561b18d = L.map(\n",
-       "                &quot;map_773b099f2ed05e628b7cb622e561b18d&quot;,\n",
+       "            var map_c448b8157de9cc32ae922f6b3904cc62 = L.map(\n",
+       "                &quot;map_c448b8157de9cc32ae922f6b3904cc62&quot;,\n",
        "                {\n",
        "                    center: [-0.915435, -89.57216],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -436,25 +392,25 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_d88a8ed7222d541082a002d71c9c661e = L.tileLayer(\n",
+       "            var tile_layer_9000bfaebebc77bfb5879f52348f58d5 = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_773b099f2ed05e628b7cb622e561b18d);\n",
+       "            ).addTo(map_c448b8157de9cc32ae922f6b3904cc62);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_2f1b1add50924d2a159efc1d2dc0e72f = L.tileLayer(\n",
+       "            var tile_layer_e592c9b154769bca2b7bdccf547f6535 = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2005\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_773b099f2ed05e628b7cb622e561b18d);\n",
+       "            ).addTo(map_c448b8157de9cc32ae922f6b3904cc62);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f18905f5c90>"
+       "<folium.folium.Map at 0x7f8dbd340c70>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -490,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -523,7 +479,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_8d481483e431e82d10b093f04456c15b {\n",
+       "                #map_67b03e77c337a92ad490a5308d29c71a {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -537,14 +493,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_8d481483e431e82d10b093f04456c15b&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_67b03e77c337a92ad490a5308d29c71a&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_8d481483e431e82d10b093f04456c15b = L.map(\n",
-       "                &quot;map_8d481483e431e82d10b093f04456c15b&quot;,\n",
+       "            var map_67b03e77c337a92ad490a5308d29c71a = L.map(\n",
+       "                &quot;map_67b03e77c337a92ad490a5308d29c71a&quot;,\n",
        "                {\n",
        "                    center: [53.018234, 158.67016],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -558,25 +514,25 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_09ff519c668e02ac7526e8fead07b556 = L.tileLayer(\n",
+       "            var tile_layer_e387683ed709e1157ab018c81850224b = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_8d481483e431e82d10b093f04456c15b);\n",
+       "            ).addTo(map_67b03e77c337a92ad490a5308d29c71a);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_1ec12b8c397d8d5e1b2f578e5ce72e46 = L.tileLayer(\n",
+       "            var tile_layer_7ea05bd7a4527d9310b14d339d7519db = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2009\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_8d481483e431e82d10b093f04456c15b);\n",
+       "            ).addTo(map_67b03e77c337a92ad490a5308d29c71a);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f18905f5c30>"
+       "<folium.folium.Map at 0x7f8d735cab30>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -612,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +601,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_ac83652c3cdf443311ed621678cbc972 {\n",
+       "                #map_70ebc3c6acec89e4f03cfb2d889cbd73 {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -659,14 +615,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_ac83652c3cdf443311ed621678cbc972&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_70ebc3c6acec89e4f03cfb2d889cbd73&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_ac83652c3cdf443311ed621678cbc972 = L.map(\n",
-       "                &quot;map_ac83652c3cdf443311ed621678cbc972&quot;,\n",
+       "            var map_70ebc3c6acec89e4f03cfb2d889cbd73 = L.map(\n",
+       "                &quot;map_70ebc3c6acec89e4f03cfb2d889cbd73&quot;,\n",
        "                {\n",
        "                    center: [65.0294256, -18.39387],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -680,25 +636,25 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_7f16b54ace074d20b9515f2cae33a874 = L.tileLayer(\n",
+       "            var tile_layer_38feda869f19ccc198317ff454f84f12 = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_ac83652c3cdf443311ed621678cbc972);\n",
+       "            ).addTo(map_70ebc3c6acec89e4f03cfb2d889cbd73);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_1275c0c543c58485181db06f9793102d = L.tileLayer(\n",
+       "            var tile_layer_2b4d6b527cb96e5981a097b22e732596 = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2021\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_ac83652c3cdf443311ed621678cbc972);\n",
+       "            ).addTo(map_70ebc3c6acec89e4f03cfb2d889cbd73);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f18905f59f0>"
+       "<folium.folium.Map at 0x7f8d735c87c0>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -715,7 +671,7 @@
     "        ], zoom_start=6)\n",
     "\n",
     "map_layer = TileLayer(\n",
-    "    tiles=tile_2020[\"tiles\"][0],\n",
+    "    tiles=tile_2021[\"tiles\"][0],\n",
     "    attr=\"VEDA\",\n",
     "    opacity=0.6,\n",
     ")\n",

--- a/example-notebooks/volcano-so2-monitoring.ipynb
+++ b/example-notebooks/volcano-so2-monitoring.ipynb
@@ -33,9 +33,9 @@
    "source": [
     "## Approach\n",
     "\n",
-    "   1. Identify available dates and temporal frequency of observations for a given collection\n",
-    "   2. Pass STAC item into raster API `/stac/tilejson.json` endpoint\n",
-    "   3. Visualize data for 2020 on a map in `folium`\n",
+    "   1. Identify available dates and temporal frequency of observations for a given collection - SO2\n",
+    "   2. Pass the STAC item into raster API `/stac/tilejson.json` endpoint\n",
+    "   3. We'll visualize tiles for each of the time steps of interest using `folium`\n",
     "   "
    ]
   },
@@ -45,7 +45,9 @@
    "source": [
     "## About the Data\n",
     "\n",
-    "[Sulfur Dioxide](https://radiantearth.github.io/stac-browser/#/external/staging-stac.delta-backend.com/collections/OMSO2PCA-COG)"
+    "Collecting measurements of Sulfur Dioxide (SO2) plumes from space is a valuable way to monitor changes in emissions. The SO2 index product is used by NASA to monitor volcanic clouds and pre-eruptive volcanic gas emissions activity. Additionally, this information is used in advisories to airlines for operational decisions. \n",
+    "\n",
+    "In this notebook, we will explore the [Sulfur Dioxide](https://radiantearth.github.io/stac-browser/#/external/staging-stac.delta-backend.com/collections/OMSO2PCA-COG) dataset and how it was used in this [VEDA Discovery article](https://www.earthdata.nasa.gov/dashboard/air-quality/discoveries/so2-volcanoes) to monitor air pollution across the globe."
    ]
   },
   {
@@ -57,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,11 +69,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Provife STAC and RASTER API endpoints\n",
+    "# Provide STAC and RASTER API endpoints\n",
     "STAC_API_URL = \"https://staging-stac.delta-backend.com\"\n",
     "RASTER_API_URL = \"https://staging-raster.delta-backend.com\"\n",
     "\n",
@@ -81,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +121,7 @@
        " 'dashboard:time_density': 'year'}"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -131,58 +133,22 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 76,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'year'"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "# Verify frequency of data available\n",
-    "collection[\"dashboard:time_density\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'datetime': ['2005-01-01T00:00:00Z', '2021-01-01T00:00:00Z'],\n",
-       " 'cog_default': {'max': 28.743701934814453, 'min': -4.941379070281982}}"
-      ]
-     },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Get collection summary\n",
-    "collection[\"summaries\"]"
+    "Examining the contents of our `collection` under `summaries` we see that the data is available from 2005 to 2021. By looking at the `dashboard:time density` we observe that the periodic frequency of these observations is yearly.  "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Returning back to our STAC API requests, let's check how many total items are available. "
+    "We can verify this by checking the total items returned from our STAC API requests. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -203,14 +169,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing the Raster Imagery\n",
+    "This makes sense as there are 17 years between 2005 - 2021. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploring Sulfur Dioxide Plumes from Space - Using the Raster API\n",
     "\n",
-    "Let's focus on the year 2020 during which much of the globe was on complete lockdown. "
+    "We'll explore three different time steps to show how NASA has observed volcanic activity in the Galápagos islands (2005), detected large scale emissions on the Kamchatka Peninsula (2009), and monitored the eruptions of Fagradalsfjall in Iceland (2021). We'll then visualize the outputs on a map using `folium`. \n",
+    "\n",
+    "To start, we'll identify which item value corresponds to each year of interest and setting a `rescaling_factor` for the SO2 index, so that values range from 0 to 1. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -228,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -246,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,14 +250,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exploring Sulfur Dioxide Plumes from Space \n",
-    "\n",
-    "We'll explore three different time steps to show how NASA has observed volcanic activity in the Galápagos islands (2005), detected large scale emissions on the Kamchatka Peninsula (2009), and monitored the eruptions of Fagradalsfjall in Iceland (2021)."
+    "Now we will pass the item id, collection name, and `rescaling_factor` to the `Raster API` endpoint. We will do this three times, one for each time step of interest, so that we can visualize each event independently. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -298,7 +271,7 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -331,7 +304,7 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -364,7 +337,7 @@
        " 'center': [0.0, 0.0, 0]}"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,12 +356,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We will then use the tile URL prepared above to create a simple visualization for each time step using `folium`. In each of these visualizations you can zoom in and out of the map's focus area to explore the data layer for that year. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Visualizing Galápagos islands (2005)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -421,7 +401,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_622722d3faa8d6ab43d18cc74a2b92a4 {\n",
+       "                #map_773b099f2ed05e628b7cb622e561b18d {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -435,14 +415,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_622722d3faa8d6ab43d18cc74a2b92a4&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_773b099f2ed05e628b7cb622e561b18d&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_622722d3faa8d6ab43d18cc74a2b92a4 = L.map(\n",
-       "                &quot;map_622722d3faa8d6ab43d18cc74a2b92a4&quot;,\n",
+       "            var map_773b099f2ed05e628b7cb622e561b18d = L.map(\n",
+       "                &quot;map_773b099f2ed05e628b7cb622e561b18d&quot;,\n",
        "                {\n",
        "                    center: [-0.915435, -89.57216],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -456,31 +436,31 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_e8f92c4bb737d1162f3033f9470abffc = L.tileLayer(\n",
+       "            var tile_layer_d88a8ed7222d541082a002d71c9c661e = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_622722d3faa8d6ab43d18cc74a2b92a4);\n",
+       "            ).addTo(map_773b099f2ed05e628b7cb622e561b18d);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_99b32eb9ca8e4c395b8678946e0c59cf = L.tileLayer(\n",
+       "            var tile_layer_2f1b1add50924d2a159efc1d2dc0e72f = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2005\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_622722d3faa8d6ab43d18cc74a2b92a4);\n",
+       "            ).addTo(map_773b099f2ed05e628b7cb622e561b18d);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f64fa4a06d0>"
+       "<folium.folium.Map at 0x7f18905f5c90>"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Set initial zoom and map\n",
+    "# Set initial zoom and map for Galápagos islands\n",
     "\n",
     "import folium\n",
     "m = Map(\n",
@@ -510,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -543,7 +523,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_4409267adcb4e7951b551c488be2dc6c {\n",
+       "                #map_8d481483e431e82d10b093f04456c15b {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -557,14 +537,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_4409267adcb4e7951b551c488be2dc6c&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_8d481483e431e82d10b093f04456c15b&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_4409267adcb4e7951b551c488be2dc6c = L.map(\n",
-       "                &quot;map_4409267adcb4e7951b551c488be2dc6c&quot;,\n",
+       "            var map_8d481483e431e82d10b093f04456c15b = L.map(\n",
+       "                &quot;map_8d481483e431e82d10b093f04456c15b&quot;,\n",
        "                {\n",
        "                    center: [53.018234, 158.67016],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -578,31 +558,31 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_3769b971405ab68cccf4e558bfdf6240 = L.tileLayer(\n",
+       "            var tile_layer_09ff519c668e02ac7526e8fead07b556 = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_4409267adcb4e7951b551c488be2dc6c);\n",
+       "            ).addTo(map_8d481483e431e82d10b093f04456c15b);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_7aae99585791b3979e07b740e7cabed1 = L.tileLayer(\n",
+       "            var tile_layer_1ec12b8c397d8d5e1b2f578e5ce72e46 = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2009\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_4409267adcb4e7951b551c488be2dc6c);\n",
+       "            ).addTo(map_8d481483e431e82d10b093f04456c15b);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f64fa4db4f0>"
+       "<folium.folium.Map at 0x7f18905f5c30>"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Set initial zoom and map\n",
+    "# Set initial zoom and map for Kamchatka Peninsula \n",
     "\n",
     "import folium\n",
     "m = Map(\n",
@@ -632,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -665,7 +645,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_86ebe0a7de87eb650cdfdcfe0f1471e8 {\n",
+       "                #map_ac83652c3cdf443311ed621678cbc972 {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -679,18 +659,18 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_86ebe0a7de87eb650cdfdcfe0f1471e8&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_ac83652c3cdf443311ed621678cbc972&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_86ebe0a7de87eb650cdfdcfe0f1471e8 = L.map(\n",
-       "                &quot;map_86ebe0a7de87eb650cdfdcfe0f1471e8&quot;,\n",
+       "            var map_ac83652c3cdf443311ed621678cbc972 = L.map(\n",
+       "                &quot;map_ac83652c3cdf443311ed621678cbc972&quot;,\n",
        "                {\n",
        "                    center: [65.0294256, -18.39387],\n",
        "                    crs: L.CRS.EPSG3857,\n",
-       "                    zoom: 7,\n",
+       "                    zoom: 6,\n",
        "                    zoomControl: true,\n",
        "                    preferCanvas: false,\n",
        "                }\n",
@@ -700,31 +680,31 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_75275ee172871f107dd70b2476024d79 = L.tileLayer(\n",
+       "            var tile_layer_7f16b54ace074d20b9515f2cae33a874 = L.tileLayer(\n",
        "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_86ebe0a7de87eb650cdfdcfe0f1471e8);\n",
+       "            ).addTo(map_ac83652c3cdf443311ed621678cbc972);\n",
        "        \n",
        "    \n",
-       "            var tile_layer_853c022b99f595f8efaf4d5f328a11b7 = L.tileLayer(\n",
+       "            var tile_layer_1275c0c543c58485181db06f9793102d = L.tileLayer(\n",
        "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2021\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
        "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_86ebe0a7de87eb650cdfdcfe0f1471e8);\n",
+       "            ).addTo(map_ac83652c3cdf443311ed621678cbc972);\n",
        "        \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f64fa4db250>"
+       "<folium.folium.Map at 0x7f18905f59f0>"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Set initial zoom and map\n",
+    "# Set initial zoom and map for Fagradalsfjall, Iceland \n",
     "\n",
     "import folium\n",
     "m = Map(\n",
@@ -732,7 +712,7 @@
     "    location=[\n",
     "         65.0294256,\n",
     "        -18.393870,\n",
-    "        ], zoom_start=7)\n",
+    "        ], zoom_start=6)\n",
     "\n",
     "map_layer = TileLayer(\n",
     "    tiles=tile_2020[\"tiles\"][0],\n",

--- a/example-notebooks/volcano-so2-monitoring.ipynb
+++ b/example-notebooks/volcano-so2-monitoring.ipynb
@@ -15,45 +15,765 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Run this notebook\n",
     "\n",
-    "You can launch this notebook in VEDA JupyterHub by clicking the link below.\n",
+    "You can launch this notebook using mybinder, by clicking the button below.\n",
     "\n",
-    "[Launch in VEDA JupyterHub (requires access)](https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/example-notebooks/volcano-so2-monitoring.ipynb&branch=main) \n",
+    "<a href=\"https://mybinder.org/v2/gh/NASA-IMPACT/veda-docs/HEAD?labpath=example-notebooks/volcano-so2-monitoring.ipynb\">\n",
+    "<img src=\"https://mybinder.org/badge_logo.svg\" alt=\"Binder\" title=\"A cute binder\" width=\"150\"/> \n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Approach\n",
     "\n",
-    "<details><summary>Learn more</summary>\n",
-    "    \n",
-    "### Inside the Hub\n",
+    "   1. Identify available dates and temporal frequency of observations for a given collection\n",
+    "   2. Pass STAC item into raster API `/stac/tilejson.json` endpoint\n",
+    "   3. Visualize data for 2020 on a map in `folium`\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## About the Data\n",
     "\n",
-    "This notebook was written on the VEDA JupyterHub and as such is designed to be run on a jupyterhub which is associated with an AWS IAM role which has been granted permissions to the VEDA data store via its bucket policy. The instance used provided 16GB of RAM. \n",
+    "[Sulfur Dioxide](https://radiantearth.github.io/stac-browser/#/external/staging-stac.delta-backend.com/collections/OMSO2PCA-COG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying the STAC API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from folium import Map, TileLayer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Provife STAC and RASTER API endpoints\n",
+    "STAC_API_URL = \"https://staging-stac.delta-backend.com\"\n",
+    "RASTER_API_URL = \"https://staging-raster.delta-backend.com\"\n",
     "\n",
-    "See (VEDA Analytics JupyterHub Access)[https://nasa-impact.github.io/veda-docs/veda-jh-access.html] for information about how to gain access.\n",
+    "# Declare collection of interest - Sulfur Dioxide\n",
+    "collection_name = \"OMSO2PCA-COG\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'OMSO2PCA-COG',\n",
+       " 'type': 'Collection',\n",
+       " 'links': [{'rel': 'items',\n",
+       "   'type': 'application/geo+json',\n",
+       "   'href': 'https://staging-stac.delta-backend.com/collections/OMSO2PCA-COG/items'},\n",
+       "  {'rel': 'parent',\n",
+       "   'type': 'application/json',\n",
+       "   'href': 'https://staging-stac.delta-backend.com/'},\n",
+       "  {'rel': 'root',\n",
+       "   'type': 'application/json',\n",
+       "   'href': 'https://staging-stac.delta-backend.com/'},\n",
+       "  {'rel': 'self',\n",
+       "   'type': 'application/json',\n",
+       "   'href': 'https://staging-stac.delta-backend.com/collections/OMSO2PCA-COG'}],\n",
+       " 'title': 'OMI/Aura Sulfur Dioxide (SO2) Total Column L3 1 day Best Pixel in 0.25 degree x 0.25 degree V3 as Cloud-Optimized GeoTIFFs (COGs)',\n",
+       " 'extent': {'spatial': {'bbox': [[-180, -90, 180, 90]]},\n",
+       "  'temporal': {'interval': [['2005-01-01T00:00:00Z',\n",
+       "     '2021-01-01T00:00:00Z']]}},\n",
+       " 'license': 'MIT',\n",
+       " 'summaries': {'datetime': ['2005-01-01T00:00:00Z', '2021-01-01T00:00:00Z'],\n",
+       "  'cog_default': {'max': 28.743701934814453, 'min': -4.941379070281982}},\n",
+       " 'description': 'OMI/Aura Sulfur Dioxide (SO2) Total Column L3 1 day Best Pixel in 0.25 degree x 0.25 degree V3 as Cloud-Optimized GeoTIFFs (COGs)',\n",
+       " 'item_assets': {'cog_default': {'type': 'image/tiff; application=geotiff; profile=cloud-optimized',\n",
+       "   'roles': ['data', 'layer'],\n",
+       "   'title': 'Default COG Layer',\n",
+       "   'description': 'Cloud optimized default layer to display on map'}},\n",
+       " 'stac_version': '1.0.0',\n",
+       " 'stac_extensions': [],\n",
+       " 'dashboard:is_periodic': True,\n",
+       " 'dashboard:time_density': 'year'}"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Fetch STAC collection\n",
+    "collection = requests.get(f\"{STAC_API_URL}/collections/{collection_name}\").json()\n",
+    "collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'year'"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Verify frequency of data available\n",
+    "collection[\"dashboard:time_density\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'datetime': ['2005-01-01T00:00:00Z', '2021-01-01T00:00:00Z'],\n",
+       " 'cog_default': {'max': 28.743701934814453, 'min': -4.941379070281982}}"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get collection summary\n",
+    "collection[\"summaries\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Returning back to our STAC API requests, let's check how many total items are available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 17 items\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check total number of items available\n",
+    "items = requests.get(f\"{STAC_API_URL}/collections/{collection_name}/items?limit=100\").json()[\"features\"]\n",
+    "print(f\"Found {len(items)} items\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing the Raster Imagery\n",
     "\n",
-    "### Outside the Hub\n",
+    "Let's focus on the year 2020 during which much of the globe was on complete lockdown. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2005-01-01T00:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Year 2005\n",
+    "print(items[16]['properties']['start_datetime'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2009-01-01T00:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Year 2009\n",
+    "print(items[12]['properties']['start_datetime'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-01-01T00:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Year 2021\n",
+    "print(items[0]['properties']['start_datetime'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rescaling_factor = \"0,1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploring Sulfur Dioxide Plumes from Space \n",
     "\n",
-    "The data is in a protected bucket. Please request access by emailng aimee@developmentseed.org or alexandra@developmentseed.org and providing your affiliation, interest in or expected use of the dataset and an AWS IAM role or user Amazon Resource Name (ARN). The team will help you configure the cognito client.\n",
+    "We'll explore three different time steps to show how NASA has observed volcanic activity in the Galápagos islands (2005), detected large scale emissions on the Kamchatka Peninsula (2009), and monitored the eruptions of Fagradalsfjall in Iceland (2021)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tilejson': '2.2.0',\n",
+       " 'version': '1.0.0',\n",
+       " 'scheme': 'xyz',\n",
+       " 'tiles': ['https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG&item=OMSO2PCA_LUT_SCD_2005&assets=cog_default&color_formula=gamma+r+1.05&colormap_name=viridis&rescale=0%2C1'],\n",
+       " 'minzoom': 0,\n",
+       " 'maxzoom': 24,\n",
+       " 'bounds': [-180.0, -90.0, 180.0, 90.0],\n",
+       " 'center': [0.0, 0.0, 0]}"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tile_2005 = requests.get(\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[16]['collection']}&item={items[16]['id']}\"\n",
+    "    \"&assets=cog_default\"\n",
+    "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
+    "    f\"&rescale={rescaling_factor}\", \n",
+    ").json()\n",
+    "tile_2005"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tilejson': '2.2.0',\n",
+       " 'version': '1.0.0',\n",
+       " 'scheme': 'xyz',\n",
+       " 'tiles': ['https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG&item=OMSO2PCA_LUT_SCD_2009&assets=cog_default&color_formula=gamma+r+1.05&colormap_name=viridis&rescale=0%2C1'],\n",
+       " 'minzoom': 0,\n",
+       " 'maxzoom': 24,\n",
+       " 'bounds': [-180.0, -90.0, 180.0, 90.0],\n",
+       " 'center': [0.0, 0.0, 0]}"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tile_2009 = requests.get(\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[12]['collection']}&item={items[12]['id']}\"\n",
+    "    \"&assets=cog_default\"\n",
+    "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
+    "    f\"&rescale={rescaling_factor}\", \n",
+    ").json()\n",
+    "tile_2009"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tilejson': '2.2.0',\n",
+       " 'version': '1.0.0',\n",
+       " 'scheme': 'xyz',\n",
+       " 'tiles': ['https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG&item=OMSO2PCA_LUT_SCD_2021&assets=cog_default&color_formula=gamma+r+1.05&colormap_name=viridis&rescale=0%2C1'],\n",
+       " 'minzoom': 0,\n",
+       " 'maxzoom': 24,\n",
+       " 'bounds': [-180.0, -90.0, 180.0, 90.0],\n",
+       " 'center': [0.0, 0.0, 0]}"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tile_2020 = requests.get(\n",
+    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={items[0]['collection']}&item={items[0]['id']}\"\n",
+    "    \"&assets=cog_default\"\n",
+    "    \"&color_formula=gamma+r+1.05&colormap_name=viridis\"\n",
+    "    f\"&rescale={rescaling_factor}\", \n",
+    ").json()\n",
+    "tile_2020"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing Galápagos islands (2005)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><span style=\"color:#565656\">Make this Notebook Trusted to load map: File -> Trust Notebook</span><iframe srcdoc=\"&lt;!DOCTYPE html&gt;\n",
+       "&lt;html&gt;\n",
+       "&lt;head&gt;\n",
+       "    \n",
+       "    &lt;meta http-equiv=&quot;content-type&quot; content=&quot;text/html; charset=UTF-8&quot; /&gt;\n",
+       "    \n",
+       "        &lt;script&gt;\n",
+       "            L_NO_TOUCH = false;\n",
+       "            L_DISABLE_3D = false;\n",
+       "        &lt;/script&gt;\n",
+       "    \n",
+       "    &lt;style&gt;html, body {width: 100%;height: 100%;margin: 0;padding: 0;}&lt;/style&gt;\n",
+       "    &lt;style&gt;#map {position:absolute;top:0;bottom:0;right:0;left:0;}&lt;/style&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://code.jquery.com/jquery-1.12.4.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css&quot;/&gt;\n",
+       "    \n",
+       "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
+       "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
+       "            &lt;style&gt;\n",
+       "                #map_622722d3faa8d6ab43d18cc74a2b92a4 {\n",
+       "                    position: relative;\n",
+       "                    width: 100.0%;\n",
+       "                    height: 100.0%;\n",
+       "                    left: 0.0%;\n",
+       "                    top: 0.0%;\n",
+       "                }\n",
+       "                .leaflet-container { font-size: 1rem; }\n",
+       "            &lt;/style&gt;\n",
+       "        \n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    \n",
+       "    \n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_622722d3faa8d6ab43d18cc74a2b92a4&quot; &gt;&lt;/div&gt;\n",
+       "        \n",
+       "&lt;/body&gt;\n",
+       "&lt;script&gt;\n",
+       "    \n",
+       "    \n",
+       "            var map_622722d3faa8d6ab43d18cc74a2b92a4 = L.map(\n",
+       "                &quot;map_622722d3faa8d6ab43d18cc74a2b92a4&quot;,\n",
+       "                {\n",
+       "                    center: [-0.915435, -89.57216],\n",
+       "                    crs: L.CRS.EPSG3857,\n",
+       "                    zoom: 7,\n",
+       "                    zoomControl: true,\n",
+       "                    preferCanvas: false,\n",
+       "                }\n",
+       "            );\n",
+       "\n",
+       "            \n",
+       "\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_e8f92c4bb737d1162f3033f9470abffc = L.tileLayer(\n",
+       "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_622722d3faa8d6ab43d18cc74a2b92a4);\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_99b32eb9ca8e4c395b8678946e0c59cf = L.tileLayer(\n",
+       "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2005\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_622722d3faa8d6ab43d18cc74a2b92a4);\n",
+       "        \n",
+       "&lt;/script&gt;\n",
+       "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
+      ],
+      "text/plain": [
+       "<folium.folium.Map at 0x7f64fa4a06d0>"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Set initial zoom and map\n",
     "\n",
-    "You should then run:\n",
+    "import folium\n",
+    "m = Map(\n",
+    "    tiles=\"OpenStreetMap\", \n",
+    "    location=[\n",
+    "         -0.915435,\n",
+    "         -89.57216,\n",
+    "        ], zoom_start=7)\n",
     "\n",
-    "```\n",
-    "%run -i 'cognito_login.py'\n",
-    "```\n",
-    "    \n",
-    "</details>"
+    "map_layer = TileLayer(\n",
+    "    tiles=tile_2005[\"tiles\"][0],\n",
+    "    attr=\"VEDA\",\n",
+    "    opacity=0.6,\n",
+    ")\n",
+    "\n",
+    "map_layer.add_to(m)\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing Kamchatka Peninsula (2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><span style=\"color:#565656\">Make this Notebook Trusted to load map: File -> Trust Notebook</span><iframe srcdoc=\"&lt;!DOCTYPE html&gt;\n",
+       "&lt;html&gt;\n",
+       "&lt;head&gt;\n",
+       "    \n",
+       "    &lt;meta http-equiv=&quot;content-type&quot; content=&quot;text/html; charset=UTF-8&quot; /&gt;\n",
+       "    \n",
+       "        &lt;script&gt;\n",
+       "            L_NO_TOUCH = false;\n",
+       "            L_DISABLE_3D = false;\n",
+       "        &lt;/script&gt;\n",
+       "    \n",
+       "    &lt;style&gt;html, body {width: 100%;height: 100%;margin: 0;padding: 0;}&lt;/style&gt;\n",
+       "    &lt;style&gt;#map {position:absolute;top:0;bottom:0;right:0;left:0;}&lt;/style&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://code.jquery.com/jquery-1.12.4.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css&quot;/&gt;\n",
+       "    \n",
+       "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
+       "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
+       "            &lt;style&gt;\n",
+       "                #map_4409267adcb4e7951b551c488be2dc6c {\n",
+       "                    position: relative;\n",
+       "                    width: 100.0%;\n",
+       "                    height: 100.0%;\n",
+       "                    left: 0.0%;\n",
+       "                    top: 0.0%;\n",
+       "                }\n",
+       "                .leaflet-container { font-size: 1rem; }\n",
+       "            &lt;/style&gt;\n",
+       "        \n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    \n",
+       "    \n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_4409267adcb4e7951b551c488be2dc6c&quot; &gt;&lt;/div&gt;\n",
+       "        \n",
+       "&lt;/body&gt;\n",
+       "&lt;script&gt;\n",
+       "    \n",
+       "    \n",
+       "            var map_4409267adcb4e7951b551c488be2dc6c = L.map(\n",
+       "                &quot;map_4409267adcb4e7951b551c488be2dc6c&quot;,\n",
+       "                {\n",
+       "                    center: [53.018234, 158.67016],\n",
+       "                    crs: L.CRS.EPSG3857,\n",
+       "                    zoom: 7,\n",
+       "                    zoomControl: true,\n",
+       "                    preferCanvas: false,\n",
+       "                }\n",
+       "            );\n",
+       "\n",
+       "            \n",
+       "\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_3769b971405ab68cccf4e558bfdf6240 = L.tileLayer(\n",
+       "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_4409267adcb4e7951b551c488be2dc6c);\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_7aae99585791b3979e07b740e7cabed1 = L.tileLayer(\n",
+       "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2009\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_4409267adcb4e7951b551c488be2dc6c);\n",
+       "        \n",
+       "&lt;/script&gt;\n",
+       "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
+      ],
+      "text/plain": [
+       "<folium.folium.Map at 0x7f64fa4db4f0>"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Set initial zoom and map\n",
+    "\n",
+    "import folium\n",
+    "m = Map(\n",
+    "    tiles=\"OpenStreetMap\", \n",
+    "    location=[\n",
+    "         53.018234,\n",
+    "         158.67016,\n",
+    "        ], zoom_start=7)\n",
+    "\n",
+    "map_layer = TileLayer(\n",
+    "    tiles=tile_2009[\"tiles\"][0],\n",
+    "    attr=\"VEDA\",\n",
+    "    opacity=0.6,\n",
+    ")\n",
+    "\n",
+    "map_layer.add_to(m)\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing Fagradalsfjall, Iceland (2021)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><span style=\"color:#565656\">Make this Notebook Trusted to load map: File -> Trust Notebook</span><iframe srcdoc=\"&lt;!DOCTYPE html&gt;\n",
+       "&lt;html&gt;\n",
+       "&lt;head&gt;\n",
+       "    \n",
+       "    &lt;meta http-equiv=&quot;content-type&quot; content=&quot;text/html; charset=UTF-8&quot; /&gt;\n",
+       "    \n",
+       "        &lt;script&gt;\n",
+       "            L_NO_TOUCH = false;\n",
+       "            L_DISABLE_3D = false;\n",
+       "        &lt;/script&gt;\n",
+       "    \n",
+       "    &lt;style&gt;html, body {width: 100%;height: 100%;margin: 0;padding: 0;}&lt;/style&gt;\n",
+       "    &lt;style&gt;#map {position:absolute;top:0;bottom:0;right:0;left:0;}&lt;/style&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://code.jquery.com/jquery-1.12.4.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;script src=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js&quot;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css&quot;/&gt;\n",
+       "    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css&quot;/&gt;\n",
+       "    \n",
+       "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
+       "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
+       "            &lt;style&gt;\n",
+       "                #map_86ebe0a7de87eb650cdfdcfe0f1471e8 {\n",
+       "                    position: relative;\n",
+       "                    width: 100.0%;\n",
+       "                    height: 100.0%;\n",
+       "                    left: 0.0%;\n",
+       "                    top: 0.0%;\n",
+       "                }\n",
+       "                .leaflet-container { font-size: 1rem; }\n",
+       "            &lt;/style&gt;\n",
+       "        \n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    \n",
+       "    \n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_86ebe0a7de87eb650cdfdcfe0f1471e8&quot; &gt;&lt;/div&gt;\n",
+       "        \n",
+       "&lt;/body&gt;\n",
+       "&lt;script&gt;\n",
+       "    \n",
+       "    \n",
+       "            var map_86ebe0a7de87eb650cdfdcfe0f1471e8 = L.map(\n",
+       "                &quot;map_86ebe0a7de87eb650cdfdcfe0f1471e8&quot;,\n",
+       "                {\n",
+       "                    center: [65.0294256, -18.39387],\n",
+       "                    crs: L.CRS.EPSG3857,\n",
+       "                    zoom: 7,\n",
+       "                    zoomControl: true,\n",
+       "                    preferCanvas: false,\n",
+       "                }\n",
+       "            );\n",
+       "\n",
+       "            \n",
+       "\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_75275ee172871f107dd70b2476024d79 = L.tileLayer(\n",
+       "                &quot;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;Data by \\u0026copy; \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://openstreetmap.org\\&quot;\\u003eOpenStreetMap\\u003c/a\\u003e, under \\u003ca target=\\&quot;_blank\\&quot; href=\\&quot;http://www.openstreetmap.org/copyright\\&quot;\\u003eODbL\\u003c/a\\u003e.&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_86ebe0a7de87eb650cdfdcfe0f1471e8);\n",
+       "        \n",
+       "    \n",
+       "            var tile_layer_853c022b99f595f8efaf4d5f328a11b7 = L.tileLayer(\n",
+       "                &quot;https://staging-raster.delta-backend.com/stac/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?collection=OMSO2PCA-COG\\u0026item=OMSO2PCA_LUT_SCD_2021\\u0026assets=cog_default\\u0026color_formula=gamma+r+1.05\\u0026colormap_name=viridis\\u0026rescale=0%2C1&quot;,\n",
+       "                {&quot;attribution&quot;: &quot;VEDA&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 0.6, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
+       "            ).addTo(map_86ebe0a7de87eb650cdfdcfe0f1471e8);\n",
+       "        \n",
+       "&lt;/script&gt;\n",
+       "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
+      ],
+      "text/plain": [
+       "<folium.folium.Map at 0x7f64fa4db250>"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Set initial zoom and map\n",
+    "\n",
+    "import folium\n",
+    "m = Map(\n",
+    "    tiles=\"OpenStreetMap\", \n",
+    "    location=[\n",
+    "         65.0294256,\n",
+    "        -18.393870,\n",
+    "        ], zoom_start=7)\n",
+    "\n",
+    "map_layer = TileLayer(\n",
+    "    tiles=tile_2020[\"tiles\"][0],\n",
+    "    attr=\"VEDA\",\n",
+    "    opacity=0.6,\n",
+    ")\n",
+    "\n",
+    "map_layer.add_to(m)\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this case study we have successfully visualized how NASA monitors sulfur dioxide emissions from space, by showcasing three different examples across the globe: volcanic activity in the Galápagos islands (2005), large scale emissions on the Kamchatka Peninsula (2009), and eruptions of Fagradalsfjall in Iceland (2021)."
    ]
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
-  "orig_nbformat": 4
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Developed a notebook walking through a previously posted VEDA discovery '[Monitoring Volcanic Sulfur Dioxide Emissions](https://www.earthdata.nasa.gov/dashboard/air-quality/discoveries/so2-volcanoes)' which explored the [Sulfur Dioxide dataset](https://radiantearth.github.io/stac-browser/#/external/staging-stac.delta-backend.com/collections/OMSO2PCA-COG?.language=en). 

The notebook explores three different time-steps to show how NASA has observed volcanic activity in the Galápagos islands (2005), detected large scale emissions on the Kamchatka Peninsula (2009), and monitored the eruptions of Fagradalsfjall in Iceland (2021). These were the three time-steps showcased in the Discovery article. Approach used both the STAC and Raster APIs, and visualized each of these time-steps on a map using `folium`. 

related to: https://github.com/NASA-IMPACT/veda-analytics/issues/46