### PR TITLE
Add link to CryoCloud JupyterBook

### DIFF
--- a/external-resources.qmd
+++ b/external-resources.qmd
@@ -17,6 +17,7 @@ This list is intended for scientists who want to get started with cloud-based, c
 
 ## Look through nicely curated lists of tools and resources
 * [NASA Openscapes Earthdata Cloud Cookbook](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/)
+* [CryoCloud JupyterBook](https://book.cryointhecloud.com/)
 * [Project Pythia - Pangeo's education hub](https://projectpythia.org/)
 * [Planetary Computer](https://planetarycomputer.microsoft.com/docs/overview/about)
 * [Geospatial Computing Platform library of training resources (by Python package)](https://crib.utwente.nl/manual/training-resources/README.html)


### PR DESCRIPTION
The [CryoCloud JupyterBook](https://book.cryointhecloud.com) has relevant resources for cloud-native Earth science data access and analysis. I added a link to the list of external resources.