### PR TITLE
Update docs-and-notebooks.qmd

### DIFF
--- a/contributing/docs-and-notebooks.qmd
+++ b/contributing/docs-and-notebooks.qmd
@@ -5,6 +5,10 @@ subtitle: Conventions for Jupyter notebooks
 
 Contribution to VEDA's documentation is always welcome - just open a [Pull Request on the veda-docs repository](https://github.com/NASA-IMPACT/veda-docs).
 
+You can submit a PR by forking the repository and submitting a PR with your fork. However, PR previews will not work for PRs from forks. You can push directly to this repository by becoming a collaborator. If you are not already a collaborator of the `veda-docs` repository, please email your github handle and  veda@uah.edu along with a message like "please add me as a collaborator to the veda-docs repository so I can push a branch". If you are not someone already familiar with the VEDA team, please add some additional information about your interest in contributing to the documentation.
+
+Once you are a collaborator, you will be able to submit a PR from a branch of this repository (that is, not a branch from a fork) and PR previews will help in the review process.
+
 Please note that this documentation site is rendered using [Quarto](https://quarto.org/), which adds a small set of configuration options on top of vanilla Markdown and Jupyter Notebooks.
 
 


### PR DESCRIPTION
PR previews were recently introduced https://github.com/NASA-IMPACT/veda-docs/pull/72, however, this will not work for PRs from forks

On the homepage for the github action [pr-preview-action](https://github.com/rossjrw/pr-preview-action) it's stated:

>This Action does not currently support deploying previews for PRs from forks, but will do so in https://github.com/rossjrw/pr-preview-action/pull/6.

This PR adds some documentation so people can be added as collaborators and then create branches for this repository (and not a fork). 

Open to other suggestions.