### PR TITLE
Add example dataset ingest example notebook, using GEOGLAM June 2023 dataset

### DIFF
--- a/notebooks/veda-operations/example-geoglam-ingest.ipynb
+++ b/notebooks/veda-operations/example-geoglam-ingest.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "1b78106c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Example Ingestion Workflow for Uploading Data to the VEDA Dashboard\n",
+    "description: A walk through of the ingestion workflow for data providers who want to add a new dataset to the VEDA Dashboard.\n",
+    "author: Jonas Sølvsteen, Kathryn Berger\n",
+    "date: July 25, 2023\n",
+    "execute:\n",
+    "  freeze: true\n",
+    "  cache: true\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a34abb82",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook is intented to be used as a reference for data providers who want to add new datasets to the VEDA Dashboard. As always it is important that the data provider has read the documentation for [Data Ingestion](https://nasa-impact.github.io/veda-docs/contributing/dataset-ingestion/) before moving forward with this notebook example. \n",
+    "\n",
+    "For example purposes, we will walk the end user through adding the GEOGLAM June 2023 dataset directly to the VEDA Dashboard. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6bb4d8f6-cfef-4d85-bb9b-c1d6b0192824",
+   "metadata": {},
+   "source": [
+    "## Authenticate with VEDA backend"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "db71852a-c1e1-4d2e-94a4-63b5b5892e55",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: You are using pip version 22.0.4; however, version 23.2.1 is available.\n",
+      "You should consider upgrading via the '/Users/kathrynaberger/Documents/Work/veda-docs/_env/bin/python3 -m pip install --upgrade pip' command.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install cognito-client --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20ae7996",
+   "metadata": {},
+   "source": [
+    "Running the following cell will trigger a request for your `CognitoClient` `username` and `password`. If you do not already have these credentails please reach out to our VEDA Data Services team for an account to be set up for you. The first time you log in using the `CognitoClient` in this notebook with the new credentials, you'll be prompted to set a new password. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8ea93d39-8283-4697-881b-95633a924d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cognito_client import CognitoClient\n",
+    "\n",
+    "client = CognitoClient(\n",
+    "    client_id=\"o8c93cebc17upumgstlbqm44f\",\n",
+    "    user_pool_id=\"us-west-2_9mMSsMcxw\",\n",
+    "    identity_pool_id=\"us-west-2:40f39c19-ab88-4d0b-85a3-3bad4eacbfc0\",\n",
+    ")\n",
+    "_ = client.login()\n",
+    "\n",
+    "TOKEN = client.access_token\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fee35629-2bde-4956-a80a-44626b3de62a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import rio_cogeo\n",
+    "import rasterio\n",
+    "import boto3\n",
+    "import requests\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9ca5a45c-6d87-4e0a-8472-cd63e19ecc8b",
+   "metadata": {},
+   "source": [
+    "## Define item metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68ad75ed",
+   "metadata": {},
+   "source": [
+    "Below we will define some of the variables to be used including the `API` address and `TARGET_FILENAME` for the datafile you want to upload. Note that in this example we will demonstrate the ingestion of GEOGLAM's June 2023 data. It is important that the file you want to upload (e.g., `CropMonitor_2023_06_28.tif` ) is located in the same repository folder as this notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ed0999b4-36c2-4bcf-8ab6-bcd8738deb52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API = \"https://ig9v64uky8.execute-api.us-west-2.amazonaws.com/staging/\"\n",
+    "\n",
+    "LOCAL_FILE_PATH = \"CropMonitor_2023_06_28.tif\"\n",
+    "YEAR, MONTH = 2023, 6\n",
+    "\n",
+    "TARGET_FILENAME = f\"CropMonitor_{YEAR}{MONTH:02}.tif\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "1035711c-64ee-4e0e-82af-277595f8a415",
+   "metadata": {},
+   "source": [
+    "## Validate data format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e7e5fa",
+   "metadata": {},
+   "source": [
+    "The following code is used to test whether the data format you are planning to upload is Cloud Optimized GeoTiff (COG) that enables more efficient workflows in the cloud environment. If the validation process identifies that it is not a COG, it will convert it into one. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "286370d2-953b-4bc7-8b43-7db4250a4dd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_is_a_cog = rio_cogeo.cog_validate(LOCAL_FILE_PATH)\n",
+    "if not file_is_a_cog:\n",
+    "    raise ValueError()\n",
+    "    print(\"File is not a COG - converting\")\n",
+    "    rio_cogeo.cog_translate(LOCAL_FILE_PATH, LOCAL_FILE_PATH, in_memory=True)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a41dbfc8-475b-430a-bd6b-84275857b2ec",
+   "metadata": {},
+   "source": [
+    "## Upload file to S3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fb9cc0f",
+   "metadata": {},
+   "source": [
+    "The following code will upload your COG data into `veda-data-store-staging` bucket. It will use the `TARGET_FILENAME` to assign the correct month and year values we have provided earlier in this notebook, under the `geoglam` bucket on `S3`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5b3fb388-f021-4719-aca7-7f9bebb0f378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = boto3.client(\"s3\")\n",
+    "BUCKET = \"veda-data-store-staging\"\n",
+    "KEY = f\"{BUCKET}/geoglam/{TARGET_FILENAME}\"\n",
+    "S3_FILE_LOCATION = f\"s3://{KEY}\"\n",
+    "\n",
+    "if False:\n",
+    "    s3.upload_file(LOCAL_FILE_PATH, KEY)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2943e433-0ce7-43af-9802-7d90f5abe26c",
+   "metadata": {},
+   "source": [
+    "## Construct dataset definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9a548ac",
+   "metadata": {},
+   "source": [
+    "Here the data provider will construct the dataset definition (and supporting metadata) that will be used for dataset ingestion. It is imperative that these values are correct and align to the data the provider is planning to upload to the VEDA Platform. For example, make sure that the `startdate` and `enddate` are realistic (e.g., an `\"enddate\":\"2023-06-31T23:59:59Z\"` would be an incorrect value for June, as it contains only 31 days). \n",
+    "\n",
+    "For further detail on metadata required for entries in the VEDA STAC to work with the VEDA Dashboard, see documentation [here.](https://nasa-impact.github.io/veda-docs/contributing/dataset-ingestion/stac-collection-conventions.html) In particular, note recommendations for the fields `is_periodic` and `time_density`. For example, in the code block below we define the `is_periodic` field as `False` because we are ingesting only one month of data. Even though we know that the monthly observations are provided routinely by GEOGLAM, we will only have a single file to ingest and so do not have a temporal range of items in the collection with a monthly time density to generate a time picker from the available data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4a046ad1-c5ad-4212-ac33-bb7c3e0f7a97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"collection\": \"geoglam\",\n",
+      "  \"title\": \"GEOGLAM Crop Monitor\",\n",
+      "  \"data_type\": \"cog\",\n",
+      "  \"spatial_extent\": {\n",
+      "    \"xmin\": -180,\n",
+      "    \"ymin\": -90,\n",
+      "    \"xmax\": 180,\n",
+      "    \"ymax\": 90\n",
+      "  },\n",
+      "  \"temporal_extent\": {\n",
+      "    \"startdate\": \"2020-01-01T00:00:00Z\",\n",
+      "    \"enddate\": \"2023-06-30T23:59:59Z\"\n",
+      "  },\n",
+      "  \"license\": \"MIT\",\n",
+      "  \"description\": \"The Crop Monitors were designed to provide a public good of open, timely, science-driven information on crop conditions in support of market transparency for the G20 Agricultural Market Information System (AMIS). Reflecting an international, multi-source, consensus assessment of crop growing conditions, status, and agro-climatic factors likely to impact global production, focusing on the major producing and trading countries for the four primary crops monitored by AMIS (wheat, maize, rice, and soybeans). The Crop Monitor for AMIS brings together over 40 partners from national, regional (i.e. sub-continental), and global monitoring systems, space agencies, agriculture organizations and universities. Read more: https://cropmonitor.org/index.php/about/aboutus/\",\n",
+      "  \"is_periodic\": false,\n",
+      "  \"time_density\": \"month\",\n",
+      "  \"sample_files\": [\n",
+      "    \"s3://veda-data-store-staging/geoglam/CropMonitor_202306.tif\"\n",
+      "  ],\n",
+      "  \"discovery_items\": [\n",
+      "    {\n",
+      "      \"discovery\": \"s3\",\n",
+      "      \"prefix\": \"geoglam/\",\n",
+      "      \"bucket\": \"veda-data-store-staging\",\n",
+      "      \"filename_regex\": \"(.*)CropMonitor_202306.tif$\"\n",
+      "    }\n",
+      "  ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = {\n",
+    "    \"collection\": \"geoglam\",\n",
+    "    \"title\": \"GEOGLAM Crop Monitor\",\n",
+    "    \"data_type\": \"cog\",\n",
+    "    \"spatial_extent\": {\"xmin\": -180, \"ymin\": -90, \"xmax\": 180, \"ymax\": 90},\n",
+    "    \"temporal_extent\": {\n",
+    "        \"startdate\": \"2020-01-01T00:00:00Z\",\n",
+    "        \"enddate\": \"2023-06-30T23:59:59Z\",\n",
+    "    },\n",
+    "    \"license\": \"MIT\",\n",
+    "    \"description\": \"The Crop Monitors were designed to provide a public good of open, timely, science-driven information on crop conditions in support of market transparency for the G20 Agricultural Market Information System (AMIS). Reflecting an international, multi-source, consensus assessment of crop growing conditions, status, and agro-climatic factors likely to impact global production, focusing on the major producing and trading countries for the four primary crops monitored by AMIS (wheat, maize, rice, and soybeans). The Crop Monitor for AMIS brings together over 40 partners from national, regional (i.e. sub-continental), and global monitoring systems, space agencies, agriculture organizations and universities. Read more: https://cropmonitor.org/index.php/about/aboutus/\",\n",
+    "    \"is_periodic\": False,\n",
+    "    \"time_density\": \"month\",\n",
+    "    \"sample_files\": [S3_FILE_LOCATION],\n",
+    "    \"discovery_items\": [\n",
+    "        {\n",
+    "            \"discovery\": \"s3\",\n",
+    "            \"prefix\": \"geoglam/\",\n",
+    "            \"bucket\": \"veda-data-store-staging\",\n",
+    "            \"filename_regex\": f\"(.*){TARGET_FILENAME}$\",\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "import json\n",
+    "\n",
+    "print(json.dumps(dataset, indent=2))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "98371241-acf4-4e2d-bb44-24dcf1c03d51",
+   "metadata": {},
+   "source": [
+    "## Validate dataset definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be31f24a",
+   "metadata": {},
+   "source": [
+    "The following code block is used to validate the above dataset definition, and if valid, confirms that it is ready to be published on the VEDA Platform. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cbe0b0b3-0dcb-4339-a110-079dae3dfca7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\"Dataset metadata is valid and ready to be published - geoglam\"]\n"
+     ]
+    }
+   ],
+   "source": [
+    "auth_header = f\"Bearer {TOKEN}\"\n",
+    "headers = {\n",
+    "    \"Authorization\": auth_header,\n",
+    "    \"content-type\": \"application/json\",\n",
+    "    \"accept\": \"application/json\",\n",
+    "}\n",
+    "response = requests.post((API + \"dataset/validate\"), json=dataset, headers=headers)\n",
+    "response.raise_for_status()\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ff44ef07-c1fa-4701-986e-cff480accc2a",
+   "metadata": {},
+   "source": [
+    "## Publish to STAC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7492daef",
+   "metadata": {},
+   "source": [
+    "The final code block below will initiate a workflow and publish the dataset to the VEDA Platform. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0c313547-be85-401e-a5e8-eaa486cbcd41",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"message\":\"Successfully published collection: geoglam. 1  workflows initiated.\",\"workflows_ids\":[\"17aa9c82-0d94-41d9-9b0b-c5939ae33005\"]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = requests.post((API + \"dataset/publish\"), json=dataset, headers=headers)\n",
+    "response.raise_for_status()\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8794df9a",
+   "metadata": {},
+   "source": [
+    "Congratulations! You have now successfully uploaded a COG dataset to the [VEDA Dashboard](https://www.earthdata.nasa.gov/dashboard/). You can now explore the data catalog to verify the ingestion process has worked successfully, as now uploaded data should be ready for viewing and exploration. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/veda-operations/example-geoglam-ingest.ipynb
+++ b/notebooks/veda-operations/example-geoglam-ingest.ipynb
@@ -21,7 +21,7 @@
    "id": "a34abb82",
    "metadata": {},
    "source": [
-    "## Introduction\n",
+    "## Approach\n",
     "\n",
     "This notebook is intented to be used as a reference for data providers who want to add new datasets to the VEDA Dashboard. As always it is important that the data provider has read the documentation for [Data Ingestion](https://nasa-impact.github.io/veda-docs/contributing/dataset-ingestion/) before moving forward with this notebook example. \n",
     "\n",
@@ -358,7 +358,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"message\":\"Successfully published collection: geoglam. 1  workflows initiated.\",\"workflows_ids\":[\"17aa9c82-0d94-41d9-9b0b-c5939ae33005\"]}\n"
+      "{\"message\":\"Successfully published collection: geoglam. 1  workflows initiated.\",\"workflows_ids\":[\"8273d764-8bdf-45b5-8334-70ffd17e0fc5\"]}\n"
      ]
     }
    ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ ipykernel~=6.4.1
 ipyleaflet
 matplotlib
 nbsphinx
+rio_cogeo
 rioxarray
 pystac_client
 sphinxcontrib-napoleon


### PR DESCRIPTION
## Description
This notebook shows an example workflow for a data provider who wants to add a new data set to the VEDA Dashboard. The examples uses the GEOGLAM June 2023 output (CropMonitor_2023_06_28.tif)* output for this walkthrough. 

*Please note the actual `.tif` file itself has not been added to this PR. Is there a best place to store this dataset? cc' @jsignell @j08lue

I've also added `rio_cogeo` to the `requirements.txt` as it was previously missing. 

## What type of example is this?
_Choose one of the following and delete the rest ([read more](https://nasa-impact.github.io/veda-docs/notebooks))_

Dataset Ingestion* 

## Checklist
_The following checklist ensures that our notebooks are internally consistent ([read more](https://nasa-impact.github.io/veda-docs/contributing/doc-and-notebooks))_

- [x] The first cell contains the rendering information with author and data
- [ ] The notebook has a **Run this Notebook** section (with filename in link) <-N/A as uploading a dataset
- [x] The notebook has an **Approach** section
- [x] All the packages that are imported in the notebooks are used within the notebook
- [x] Any complex geometries are accessed from remote storage
- [x] Each code cell comes after a markdown cell containing explantory text
- [x] All cells in the notebook book have been run in order with a fresh kernel (cell numbers should be 1, 2, 3, 4, ...)
- [ ] If the example type is **Dataset** the filename is `<collection_id>.ipynb`
