### PR TITLE
Catalog ingest docs revision

### DIFF
--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -7,7 +7,7 @@ subtitle: "How to load metadata with our STAC API"
 
 The next step is to divide all the data into logical collections. A collection is basically what it sounds like, a collection of data files that share the same properties like, the data it's measuring, the periodicity, the spatial region, etc. For example, current VEDA datasets like `no2-mean` and `no2-diff` should be two different collections, because one measures the mean levels of nitrogen dioxide and the other the differences in observed levels. Likewise, datasets like `no2-monthly` and `no2-yearly` should be different because the periodicity is different.
 
-One you have logically grouped the datasets into collections, you will need to create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the `s3` bucket. An example is shown below:
+One you have logically grouped the datasets into collections, you will need to create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the s3 bucket. An example is shown below:
 
 `lis-global-da-evap.json`
 
@@ -80,7 +80,7 @@ The following table describes what each of these fields mean:
 </details>
 
 
-> Note: The steps after this are technical, so at this point the scientists can send the json to the VEDA team and they'll handle the publication process.
+> Note: The steps after this are technical, so at this point the scientists open a PR on the [veda-data](https://github.com/NASA-IMPACT/veda-data) repo and a member of the VEDA team will handle the publication process.
 
 
 

--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -80,7 +80,7 @@ The following table describes what each of these fields mean:
 </details>
 
 
-> Note: The steps after this are technical, so at this point the scientists open a PR on the [veda-data](https://github.com/NASA-IMPACT/veda-data) repo and a member of the VEDA team will handle the publication process.
+> Note: The steps after this are technical, so at this point open a PR on the [veda-data](https://github.com/NASA-IMPACT/veda-data) GitHub repository and a member of the VEDA team will handle the publication process.
 
 
 

--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -5,9 +5,9 @@ subtitle: "How to load metadata with our STAC API"
 
 ## STEP III: Create dataset definitions
 
-The next step is to divide all the data into logical collections. A collection is basically what it sounds like, a collection of data files that share the same properties like, the data it's measuring, the periodicity, the spatial region, etc. Examples no2-mean and no2-diff should be two different collections, because one measures the mean and the other the diff. no2-monthly and no2-yearly should be different because the periodicity is different.
+The next step is to divide all the data into logical collections. A collection is basically what it sounds like, a collection of data files that share the same properties like, the data it's measuring, the periodicity, the spatial region, etc. For example, current VEDA datasets like `no2-mean` and `no2-diff` should be two different collections, because one measures the mean levels of nitrogen dioxide and the other the differences in observed levels. Likewise, datasets like `no2-monthly` and `no2-yearly` should be different because the periodicity is different.
 
-Once you've logically grouped the datasets into collections, create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the s3 bucket. An example is shown below:
+One you have logically grouped the datasets into collections, you will need to create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the `s3` bucket. An example is shown below:
 
 `lis-global-da-evap.json`
 
@@ -80,7 +80,7 @@ The following table describes what each of these fields mean:
 </details>
 
 
-> Note: The steps after this are technical, so at this point the scientists can send the json to the VEDAteam and they'll handle the publication process.
+> Note: The steps after this are technical, so at this point the scientists can send the json to the VEDA team and they'll handle the publication process.
 
 
 
@@ -96,7 +96,7 @@ To use the VEDA Ingestion API to schedule ingestion/publication of the data foll
 
 ### 1. Obtain credentials from a VEDA team member
 
-Ask a VEDA team member to create credentials (username and password) for VEDA auth.
+Ask a VEDA team member to create `Cognito` credentials (username and password) for VEDA authentication.
 
 ### 2. Export username and password
 

--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -7,7 +7,7 @@ subtitle: "How to load metadata with our STAC API"
 
 The next step is to divide all the data into logical collections. A collection is basically what it sounds like, a collection of data files that share the same properties like, the data it's measuring, the periodicity, the spatial region, etc. For example, current VEDA datasets like `no2-mean` and `no2-diff` should be two different collections, because one measures the mean levels of nitrogen dioxide and the other the differences in observed levels. Likewise, datasets like `no2-monthly` and `no2-yearly` should be different because the periodicity is different.
 
-One you have logically grouped the datasets into collections, you will need to create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the s3 bucket. An example is shown below:
+Once you have logically grouped the datasets into collections, you will need to create dataset definitions for each of these collections. The data definition is a json file that contains some metadata of the dataset and information on how to discover these datasets in the s3 bucket. An example is shown below:
 
 `lis-global-da-evap.json`
 

--- a/contributing/dataset-ingestion/file-preparation.qmd
+++ b/contributing/dataset-ingestion/file-preparation.qmd
@@ -76,7 +76,7 @@ Make sure that the COG filename is meaningful and contains the datetime associat
 
 ## STEP II: Upload to the VEDA data store
 
-Once you have the COGs, obtain permissions to upload them to the `veda-data-store-staging` bucket.
+Once you have the COGs, obtain permissions (`Cognito` credentials) from the VEDA team to upload them to the `veda-data-store-staging` bucket.
 
 Upload the data to a sensible location inside the bucket.
 Example: `s3://veda-data-store-staging/<collection-id>/`

--- a/contributing/dataset-ingestion/index.qmd
+++ b/contributing/dataset-ingestion/index.qmd
@@ -12,7 +12,7 @@ from the original datafiles without copies or multiple versions.
 
 For dataset ingestion, generally four steps are required. Depending on the capacity of the dataset provider, some of the steps can be completed by the VEDA team on request.
 
-The data ingestion process requires Cognito credentials (username and password). In order to retrieve these credentials, you'll need to contact a member of the VEDA Data Services Team (email: veda@uah.edu) who can set up an account and credentials for you. The first time you log in using the Cognito Client, you will be prompted to set a new password.
+The data ingestion process requires `Cognito` credentials (username and password). In order to retrieve these credentials, you'll need to contact a member of the VEDA Data Services Team at [veda@uah.edu](mailto:veda@uah.edu) who can set up an account and credentials for you. The first time you log in using the `Cognito Client`, you will be prompted to set a new password.
 
 Complete as many steps of the process as you have capacity or authorization to. Please see the guides below on: 
 


### PR DESCRIPTION
## Description
This PR is the second half of revisions made to documentation around Data Ingestion, particularly focusing on the Data Catalog ingestion process. (See earlier PR [here](https://github.com/NASA-IMPACT/veda-docs/pull/92)). In this PR, clarifying text has been added, as well as signposting on who to contact within the VEDA team, and when to open a PR on `veda-data` with the end user's `json` file for their dataset of interest. 

Specifically, within the `index.qmd`: 
* the VEDA email address has been added (closes #93 )
* minor revisions to text
 
Within the `catalog-ingestion.qmd`:
* fixed a typo, 
* added refining text 
* signposting to end users to open a PR on the `veda-data` repo with the json for the dataset they want to ingest (closes #94 )

Within the `file-preparation.qmd`:
* added clarification on  credentials required (i.e., `Cognito`)


