### PR TITLE
clarify difference in STAC nbs and data ingest

### DIFF
--- a/contributing/dataset-ingestion/index.qmd
+++ b/contributing/dataset-ingestion/index.qmd
@@ -14,11 +14,15 @@ For dataset ingestion, generally four steps are required. Depending on the capac
 
 The data ingestion process requires `Cognito` credentials (username and password). In order to retrieve these credentials, you'll need to contact a member of the VEDA Data Services Team at [veda@uah.edu](mailto:veda@uah.edu) who can set up an account and credentials for you. The first time you log in using the `Cognito Client`, you will be prompted to set a new password.
 
-Complete as many steps of the process as you have capacity or authorization to. Please see the guides below on: 
+Complete as many steps of the process as you have capacity or authorization to. Please follow the steps and guides outlined below: 
 
-0. Open a dedicated [pull request in the veda-data-pipelines repository](https://github.com/NASA-IMPACT/veda-data-pipelines/issues/new?assignees=&labels=dataset&template=add-new-dataset-simple.md&title=Add+%3Cdataset+title%3E)
+0. Open a dedicated [pull request in the veda-data-pipelines repository](https://github.com/NASA-IMPACT/veda-data-pipelines/issues/new?assignees=&labels=dataset&template=add-new-dataset-simple.md&title=Add+%3Cdataset+title%3E). Please read through these docs fully first as you they will help supply the information required to complete the PR. 
 1. Transform datasets to conform with cloud-optimized file formats - see [file preparation](./file-preparation.qmd)
 2. Upload files to storage (may be skipped, if data is cloud-optimized and in `us-west-2`)
-3. Create compliant metadata records for our STAC - see [example](/notebooks/veda-operations/stac-collection-creation.html) and [conventions](./stac-collection-conventions.qmd) for STAC collections
-and [example](/notebooks/veda-operations/stac-item-creation.html) and [conventions](./stac-item-conventions.qmd) for STAC items.
-4. Load those records into the VEDA STAC - see [catalog ingestion](./catalog-ingestion.qmd)
+3. Load those records into the VEDA STAC - see [catalog ingestion](./catalog-ingestion.qmd)
+
+For a walk through of the full process outlined above, please refer to this [example notebook](https://github.com/NASA-IMPACT/veda-data/blob/main/transformation-scripts/example-template/example-geoglam-ingest.ipynb). This notebook uses the `GEOGLAM June 2023` dataset as an example, but please use this as a guide for the ingestion process (and required dataset defintions), replacing the GEOGLAM dataset with your own. 
+
+Stuck on how to develop compliant metadata records for your dataset? Checkout the following notebooks and resources to help provide you with the STAC metadata required to [create the dataset definitions needed for catalog ingestion](https://nasa-impact.github.io/veda-docs/contributing/dataset-ingestion/catalog-ingestion.html).   
+* How to create STAC Collections - see this [example notebook](/notebooks/veda-operations/stac-collection-creation.html) and related STAC [conventions](./stac-collection-conventions.qmd) 
+* How to create STAC Items - see this [example notebook](/notebooks/veda-operations/stac-item-creation.html) and [conventions](./stac-item-conventions.qmd)s.

--- a/contributing/dataset-ingestion/index.qmd
+++ b/contributing/dataset-ingestion/index.qmd
@@ -16,7 +16,7 @@ The data ingestion process requires `Cognito` credentials (username and password
 
 Complete as many steps of the process as you have capacity or authorization to. Please follow the steps and guides outlined below: 
 
-0. Open a dedicated [pull request in the veda-data-pipelines repository](https://github.com/NASA-IMPACT/veda-data-pipelines/issues/new?assignees=&labels=dataset&template=add-new-dataset-simple.md&title=Add+%3Cdataset+title%3E). Please read through these docs fully first as you they will help supply the information required to complete the PR. 
+0. Open a dedicated [pull request in the veda-data repository](https://github.com/NASA-IMPACT/veda-data). Please read through these docs fully first as you they will help supply the information required to complete the PR. Use this ["new dataset" template to open a new issue and get started](https://github.com/NASA-IMPACT/veda-data/issues/new?assignees=&labels=dataset&projects=&template=new-dataset.yaml&title=New+Dataset%3A+%3Cdataset+title%3E). 
 1. Transform datasets to conform with cloud-optimized file formats - see [file preparation](./file-preparation.qmd)
 2. Upload files to storage (may be skipped, if data is cloud-optimized and in `us-west-2`)
 3. Load those records into the VEDA STAC - see [catalog ingestion](./catalog-ingestion.qmd)

--- a/contributing/docs-and-notebooks.qmd
+++ b/contributing/docs-and-notebooks.qmd
@@ -1,5 +1,5 @@
 ---
-title: Example Notebook Submission
+title: Usage Example Notebook Submission
 subtitle: Conventions for Jupyter notebooks
 ---
 

--- a/contributing/index.qmd
+++ b/contributing/index.qmd
@@ -7,6 +7,6 @@ Please see the sections below for documentation on
 
 1. [Dataset ingestion](./dataset-ingestion/index.qmd) into the VEDA data store and STAC
 2. Configuration of [Dataset information pages](./dashboard-configuration/dataset-configuration.qmd) and [Discoveries](./dashboard-configuration/discovery-configuration.qmd) on the VEDA Dashboard
-3. [Example notebooks](./docs-and-notebooks.qmd) that illustrate the use of datasets or compute methods
+3. [Usage example notebooks](./docs-and-notebooks.qmd) that illustrate the use of datasets or compute methods
 
 Note: If you move a page or notebook, make sure to add a redirect link according to the [quarto docs](https://quarto.org/docs/websites/website-navigation.html#redirects)


### PR DESCRIPTION
## Description

This PR is a continued revision of the documentation for clarity. Specifically it addresses the confusion between the VEDA specific STAC metadata requests made by the `GEOGLAM` notebook and documentation vs. the STAC Collection and STAC Item creation notebooks. 

This notebook addresses issues #69 , #95 , and #96.

Additionally, the wording around example notebook contributions as been clarified to "usage example notebook contributions" to clarify the confusion around the notebooks referenced throughout the documentation.  

Lastly, the links for the "new dataset" template now point to `veda-data` and not `veda-data-pipelines` as they had originally. 

## What type of example is this?

Documentation refinement