### PR TITLE
Upate the link for content documentation

### DIFF
--- a/contributing/dashboard-configuration/discovery-configuration.qmd
+++ b/contributing/dashboard-configuration/discovery-configuration.qmd
@@ -22,7 +22,7 @@ By this point, you should have a few things:
 
     2. Using your local environment, create a branch for your Discovery
 
-    3. Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md#stories) section of the Github documentation, create your discovery mdx file
+    3. Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md) section of the Github documentation, create your discovery mdx file
 
     4. Add relevant files and assets as needed
 

--- a/contributing/dashboard-configuration/discovery-configuration.qmd
+++ b/contributing/dashboard-configuration/discovery-configuration.qmd
@@ -22,7 +22,7 @@ By this point, you should have a few things:
 
     2. Using your local environment, create a branch for your Discovery
 
-    3. Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-config/blob/develop/docs/CONTENT.md) section of the Github documentation, create your discovery mdx file
+    3. Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md#stories) section of the Github documentation, create your discovery mdx file
 
     4. Add relevant files and assets as needed
 
@@ -34,7 +34,7 @@ By this point, you should have a few things:
 
        ![Branching on GitHub](https://res.cloudinary.com/almanac/image/upload/v1678300216/workspace_portal_uploads/hw7elccu5sil1sy2qu4c.png)
 
-       Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-config/blob/develop/docs/CONTENT.md) section of the Github documentation, create your discovery mdx file
+       Following the guidelines outlined in the [Content](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md) section of the Github documentation, create your discovery mdx file
 
     2. Add relevant files and assets as needed
 


### PR DESCRIPTION
We. moved the documentation of Veda content creation to UI repo. This Pr updates the link for Veda content documentation. 