### PR TITLE
Update apis.qmd

### DIFF
--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -88,7 +88,7 @@ The following table describes what each of these fields mean:
 
 The publication process involves 3 steps:
 
-1. [VEDA] Publishing to the development STAC catalog `https://dev-stac.delta-backend.com`
+1. [VEDA] Publishing to the development STAC catalog `https://dev.delta-backend.com/api/stac`
 2. [EIS] Reviewing the collection/items published to the dev STAC catalog
 3. [VEDA] Publishing to the staging STAC catalog `https://staging-stac.delta-backend.com`
 

--- a/notebooks/templates/template-accessing-the-data-directly.ipynb
+++ b/notebooks/templates/template-accessing-the-data-directly.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "21dec434-0eee-4c31-9dfd-f07445c3136e",
    "metadata": {},
@@ -27,7 +26,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "01cbb159-2789-463d-8279-4b104107f185",
    "metadata": {},
@@ -40,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7fc7fb2f-c356-459b-9806-5075e6d8d1f5",
    "metadata": {},
@@ -73,7 +70,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "47280eab-909a-4331-8b6c-c11892c6ed75",
    "metadata": {},
@@ -86,7 +82,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f56368ca-2159-4fb4-ad1c-38a30b41b773",
    "metadata": {},
@@ -113,7 +108,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e54a4768-7677-4597-a241-219e675a9e66",
    "metadata": {
@@ -126,7 +120,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "65003a57-ba12-409a-8e73-8f7b25fe34f5",
    "metadata": {
@@ -138,8 +131,8 @@
     "You can discover available collections the following ways:\n",
     "\n",
     "* Programmatically: see example in the `list-collections.ipynb` notebook\n",
-    "* JSON API: https://dev-stac.delta-backend.com/collections\n",
-    "* STAC Browser: http://veda-dev-stac-browser.s3-website-us-west-2.amazonaws.com"
+    "* JSON API: https://staging-stac.delta-backend.com/collections\n",
+    "* STAC Browser: http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com"
    ]
   },
   {
@@ -155,7 +148,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d21d96ab-411a-4ebd-91f7-2425b2b93298",
    "metadata": {},
@@ -168,7 +160,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d7f38c49-a7dd-485b-8ba2-aa84330fff34",
    "metadata": {},
@@ -206,7 +197,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e7ad8e7f-5943-44c9-b2bc-26d2c2497e53",
    "metadata": {},
@@ -217,7 +207,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f8a10cfd-a645-480d-aca6-bcf3986c1967",
    "metadata": {
@@ -248,7 +237,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0520f739-0691-48b7-b6f9-f043a4c2e6a9",
    "metadata": {},
@@ -267,7 +255,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b66e474f-101a-4dc4-98b7-cd0bd6f2637f",
    "metadata": {},
@@ -296,7 +283,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4244bd36-d75d-4001-94ff-8ebda6287334",
    "metadata": {
@@ -337,7 +323,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "48a7f988-3676-4f7a-9242-2a6a762b312a",
    "metadata": {},
@@ -357,7 +342,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "96616480-5d60-4e66-b9a2-a86403dadf94",
    "metadata": {},
@@ -370,7 +354,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "66f38729-98af-496f-a1fc-5e0ca6f51cd7",
    "metadata": {},
@@ -391,7 +374,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "34d5a8a1-3e98-4ec0-bbe3-d20310f88778",
    "metadata": {},
@@ -439,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/templates/template-using-the-raster-api.ipynb
+++ b/notebooks/templates/template-using-the-raster-api.ipynb
@@ -38,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0fe4902f-b2c7-44b5-9f3f-cb59a26fbf16",
    "metadata": {},
@@ -111,8 +110,8 @@
     "You can discover available collections the following ways:\n",
     "\n",
     "* Programmatically: see example in the `list-collections.ipynb` notebook\n",
-    "* JSON API: https://dev-stac.delta-backend.com/collections\n",
-    "* STAC Browser: http://veda-dev-stac-browser.s3-website-us-west-2.amazonaws.com"
+    "* JSON API: https://staging-stac.delta-backend.com/collections\n",
+    "* STAC Browser: http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com"
    ]
   },
   {
@@ -351,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -24,8 +24,8 @@ Maintenance on the staging environment will be announced internally and selected
 
 ### Development, aka Dev (experimental work, expected downtime)
 
-* STAC browser: [veda-dev-stac-browser](http://veda-dev-stac-browser.s3-website-us-west-2.amazonaws.com/)
-* STAC API (metadata): [https://dev-stac.delta-backend.com/api/stac/docs](https://dev-stac.delta-backend.com/api/stac/docs)
-* List collections: [https://dev-stac.delta-backend.com/api/stac/collections](https://dev-stac.delta-backend.com/api/stac/collections)
-* Raster API (tiling): [https://dev-raster.delta-backend.com/api/raster/docs](https://dev-raster.delta-backend.com/api/raster/docs)
-* STAC viewer (experimental): [https://dev-stac.delta-backend.com/index.html](https://dev-stac.delta-backend.com/index.html)
+* STAC browser: [veda-dev-stac-browser](https://dev.delta-backend.com)
+* STAC API (metadata): [https://dev.delta-backend.com/api/stac/docs](https://dev.delta-backend.com/api/stac/docs)
+* List collections: [https://dev.delta-backend.com/api/stac/collections](https://dev.delta-backend.com/api/stac/collections)
+* Raster API (tiling): [https://dev.delta-backend.com/api/raster/docs](https://dev.delta-backend.com/api/raster/docs)
+* STAC viewer (experimental): [https://dev.delta-backend.com/api/stac/index.html](https://dev.delta-backend.com/api/stac/index.html)

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -25,7 +25,7 @@ Maintenance on the staging environment will be announced internally and selected
 ### Development, aka Dev (experimental work, expected downtime)
 
 * STAC browser: [veda-dev-stac-browser](http://veda-dev-stac-browser.s3-website-us-west-2.amazonaws.com/)
-* STAC API (metadata): [https://dev-stac.delta-backend.com/docs](https://dev-stac.delta-backend.com/docs)
-* List collections: [https://dev-stac.delta-backend.com/collections](https://dev-stac.delta-backend.com/collections)
-* Raster API (tiling): [https://dev-raster.delta-backend.com/docs](https://dev-raster.delta-backend.com/docs)
+* STAC API (metadata): [https://dev-stac.delta-backend.com/api/stac/docs](https://dev-stac.delta-backend.com/api/stac/docs)
+* List collections: [https://dev-stac.delta-backend.com/api/stac/collections](https://dev-stac.delta-backend.com/api/stac/collections)
+* Raster API (tiling): [https://dev-raster.delta-backend.com/api/raster/docs](https://dev-raster.delta-backend.com/api/raster/docs)
 * STAC viewer (experimental): [https://dev-stac.delta-backend.com/index.html](https://dev-stac.delta-backend.com/index.html)


### PR DESCRIPTION
Fix links to dev APIs

We also need to update the dev stac browser to use https://dev-stac.delta-backend.com/api/stac/ but I'm not sure where that deployment is being maintained at the moment.  @anayeaye @slesaad if you point me in the right direction I can try and update the dev STAC browser.