### PR TITLE
temporary redirect broken dev browser link to radiant earth demo

### DIFF
--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -24,7 +24,7 @@ Maintenance on the staging environment will be announced internally and selected
 
 ### Development, aka Dev (experimental work, expected downtime)
 
-* STAC browser: [veda-dev-stac-browser](https://dev.delta-backend.com)
+* STAC browser: [veda-dev-stac-browser](https://radiantearth.github.io/stac-browser/#/external/dev.delta-backend.com/api/stac)
 * STAC API (metadata): [https://dev.delta-backend.com/api/stac/docs](https://dev.delta-backend.com/api/stac/docs)
 * List collections: [https://dev.delta-backend.com/api/stac/collections](https://dev.delta-backend.com/api/stac/collections)
 * Raster API (tiling): [https://dev.delta-backend.com/api/raster/docs](https://dev.delta-backend.com/api/raster/docs)


### PR DESCRIPTION
## What
This PR temporarily updates the link to the dev stac-browser in apis.qmd. No notebook changes.