### PR TITLE
feat: update links to use dev.openveda.cloud

### DIFF
--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -118,6 +118,7 @@ password = os.environ.get("password")
 
 # base url for the workflows api
 # experimental / subject to change in the future
+# DISCLAIMER: coming soon, not yet available
 base_url = "https://dev.openveda.cloud/api/workflows"
 
 # endpoint to get the token from

--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -118,7 +118,7 @@ password = os.environ.get("password")
 
 # base url for the workflows api
 # experimental / subject to change in the future
-base_url = "https://dev-api.delta-backend.com"
+base_url = "https://dev.openveda.cloud/api/workflows"
 
 # endpoint to get the token from
 token_url = f"{base_url}/token"

--- a/contributing/dataset-ingestion/catalog-ingestion.qmd
+++ b/contributing/dataset-ingestion/catalog-ingestion.qmd
@@ -88,7 +88,7 @@ The following table describes what each of these fields mean:
 
 The publication process involves 3 steps:
 
-1. [VEDA] Publishing to the development STAC catalog `https://dev.delta-backend.com/api/stac`
+1. [VEDA] Publishing to the development STAC catalog `https://dev.openveda.cloud/api/stac`
 2. [EIS] Reviewing the collection/items published to the dev STAC catalog
 3. [VEDA] Publishing to the staging STAC catalog `https://staging-stac.delta-backend.com`
 

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -24,8 +24,8 @@ Maintenance on the staging environment will be announced internally and selected
 
 ### Development, aka Dev (experimental work, expected downtime)
 
-* STAC browser: [veda-dev-stac-browser (temporarily hosted by radiantearth.github.io)](https://radiantearth.github.io/stac-browser/#/external/dev.delta-backend.com/api/stac)
-* STAC API (metadata): [https://dev.delta-backend.com/api/stac/docs](https://dev.delta-backend.com/api/stac/docs)
-* List collections: [https://dev.delta-backend.com/api/stac/collections](https://dev.delta-backend.com/api/stac/collections)
-* Raster API (tiling): [https://dev.delta-backend.com/api/raster/docs](https://dev.delta-backend.com/api/raster/docs)
-* STAC viewer (experimental): [https://dev.delta-backend.com/api/stac/index.html](https://dev.delta-backend.com/api/stac/index.html)
+* STAC browser: [veda-dev-stac-browser](https://dev.openveda.cloud/)
+* STAC API (metadata): [https://dev.openveda.cloud/api/stac/docs](https://dev.openveda.cloud/api/stac/docs)
+* List collections: [https://dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
+* Raster API (tiling): [https://dev.openveda.cloud/api/raster/docs](https://dev.openveda.cloud/api/raster/docs)
+* STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](https://dev.openveda.cloud/api/stac/index.html)


### PR DESCRIPTION
## Description
- This PR updates all the `https://dev.delta-backend.com` references to `https://dev.openveda.cloud`. 

