### PR TITLE
Add OGC Features API to Dev/Staging API Docs

### DIFF
--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -16,22 +16,19 @@ Maintenance on the staging environment will be announced internally and selected
 ### Staging (maintenance will be announced):
 
 * STAC browser: [veda-staging-stac-browser](http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com/)
-* STAC API (metadata): [https://staging-stac.delta-backend.com/docs](https://staging-stac.delta-backend.com/docs)
-* List collections: [https://staging-stac.delta-backend.com/collections](https://staging-stac.delta-backend.com/collections)
-* Raster API (tiling): [https://staging-raster.delta-backend.com/docs](https://staging-raster.delta-backend.com/docs)
-* STAC viewer (experimental): [https://staging-stac.delta-backend.com/index.html](https://staging-stac.delta-backend.com/index.html)
-* OGC Features docs: [https://firenrt.delta-backend.com](https://firenrt.delta-backend.com)
-* OGC Features tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
+* STAC API (metadata): https://staging-stac.delta-backend.com/docs
+* List collections: https://staging-stac.delta-backend.com/collections
+* Raster API (map tiles and timeseries): https://staging-raster.delta-backend.com/docs
+* Features API (vector data): https://firenrt.delta-backend.com - see also the [usage tutorial](../notebooks/tutorials/mapping-fires.qmd)
+* STAC viewer (experimental): https://staging-stac.delta-backend.com/index.html
 
 ### Development, aka Dev (experimental work, expected downtime)
 
 * STAC browser: [veda-dev-stac-browser](https://dev.openveda.cloud/)
-* STAC API (metadata): [https://dev.openveda.cloud/api/stac/docs](https://dev.openveda.cloud/api/stac/docs)
-* List collections: [https://dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
-* Raster API (tiling): [https://dev.openveda.cloud/api/raster/docs](https://dev.openveda.cloud/api/raster/docs)
-* STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](https://dev.openveda.cloud/api/stac/index.html)
-* OGC Features docs: [https://firenrt.delta-backend.com](https://firenrt.delta-backend.com)
-* OGC Features tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
+* STAC API (metadata): https://dev.openveda.cloud/api/stac/docs
+* List collections: https://dev.openveda.cloud/api/stac/collections
+* Raster API (map tiles and timeseries): https://dev.openveda.cloud/api/raster/docs
+* STAC viewer (experimental): https://dev.openveda.cloud/api/stac/index.html
 
 ## Using tile layers in external services
 

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -20,8 +20,8 @@ Maintenance on the staging environment will be announced internally and selected
 * List collections: [https://staging-stac.delta-backend.com/collections](https://staging-stac.delta-backend.com/collections)
 * Raster API (tiling): [https://staging-raster.delta-backend.com/docs](https://staging-raster.delta-backend.com/docs)
 * STAC viewer (experimental): [https://staging-stac.delta-backend.com/index.html](https://staging-stac.delta-backend.com/index.html)
-* OGC Features API collections: [https://firenrt.delta-backend.com/collections](https://firenrt.delta-backend.com/collections)
-* OGC Features API tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
+* OGC Features docs: [https://firenrt.delta-backend.com](https://firenrt.delta-backend.com)
+* OGC Features tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
 
 ### Development, aka Dev (experimental work, expected downtime)
 
@@ -30,9 +30,8 @@ Maintenance on the staging environment will be announced internally and selected
 * List collections: [https://dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
 * Raster API (tiling): [https://dev.openveda.cloud/api/raster/docs](https://dev.openveda.cloud/api/raster/docs)
 * STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](https://dev.openveda.cloud/api/stac/index.html)
-* OGC Features API collections: [https://firenrt.delta-backend.com/collections](https://firenrt.delta-backend.com/collections)
-* OGC Features API tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
-
+* OGC Features docs: [https://firenrt.delta-backend.com](https://firenrt.delta-backend.com)
+* OGC Features tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
 
 ## Using tile layers in external services
 

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -16,19 +16,19 @@ Maintenance on the staging environment will be announced internally and selected
 ### Staging (maintenance will be announced):
 
 * STAC browser: [veda-staging-stac-browser](http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com/)
-* STAC API (metadata): https://staging-stac.delta-backend.com/docs
-* List collections: https://staging-stac.delta-backend.com/collections
-* Raster API (map tiles and timeseries): https://staging-raster.delta-backend.com/docs
-* Features API (vector data): https://firenrt.delta-backend.com - see also the [usage tutorial](../notebooks/tutorials/mapping-fires.qmd)
-* STAC viewer (experimental): https://staging-stac.delta-backend.com/index.html
+* STAC API (metadata): [staging-stac.delta-backend.com/docs](https://staging-stac.delta-backend.com/docs)
+* List collections: [staging-stac.delta-backend.com/collections](https://staging-stac.delta-backend.com/collections)
+* Raster API (map tiles and timeseries): [staging-raster.delta-backend.com/docs](https://staging-raster.delta-backend.com/docs)
+* Features API (vector data): [firenrt.delta-backend.com](https://firenrt.delta-backend.com) - see also the [usage tutorial](../notebooks/tutorials/mapping-fires.html)
+* STAC viewer (experimental): [staging-stac.delta-backend.com](https://staging-stac.delta-backend.com/index.html)
 
 ### Development, aka Dev (experimental work, expected downtime)
 
 * STAC browser: [veda-dev-stac-browser](https://dev.openveda.cloud/)
-* STAC API (metadata): https://dev.openveda.cloud/api/stac/docs
-* List collections: https://dev.openveda.cloud/api/stac/collections
-* Raster API (map tiles and timeseries): https://dev.openveda.cloud/api/raster/docs
-* STAC viewer (experimental): https://dev.openveda.cloud/api/stac/index.html
+* STAC API (metadata): [dev.openveda.cloud/api/stac/docs](https://dev.openveda.cloud/api/stac/docs)
+* List collections: [dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
+* Raster API (map tiles and timeseries): [https://dev.openveda.cloud/api/raster/docs](dev.openveda.cloud/api/raster/docs)
+* STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](dev.openveda.cloud/api/stac/)
 
 ## Using tile layers in external services
 
@@ -51,8 +51,8 @@ That is because, unfortunately, neither XYZ nor WMTS have time series capabiliti
 
 You can see how to retrieve time steps and tile layer URLs from these tutorial Python notebooks (mostly REST API calls):
 
-1. [Using /stac/tilejson.json with STAC collection and item IDs](../notebooks/datasets/ocean-npp-timeseries-analysis.qmd#visualizing-the-raster-imagery)
-2. [Creating layers from filters and mosaics (advanced)](../notebooks/quickstarts/hls-visualization.qmd)
+1. [Using /stac/tilejson.json with STAC collection and item IDs](../notebooks/datasets/ocean-npp-timeseries-analysis.html#visualizing-the-raster-imagery)
+2. [Creating layers from filters and mosaics (advanced)](../notebooks/quickstarts/hls-visualization.html)
 
 It comes down to querying for STAC items (timesteps) and then asking the Raster API for `tilejson.json` specifications for the items you are interested in.
 

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -20,6 +20,8 @@ Maintenance on the staging environment will be announced internally and selected
 * List collections: [https://staging-stac.delta-backend.com/collections](https://staging-stac.delta-backend.com/collections)
 * Raster API (tiling): [https://staging-raster.delta-backend.com/docs](https://staging-raster.delta-backend.com/docs)
 * STAC viewer (experimental): [https://staging-stac.delta-backend.com/index.html](https://staging-stac.delta-backend.com/index.html)
+* OGC Features API collections: [https://firenrt.delta-backend.com/collections](https://firenrt.delta-backend.com/collections)
+* OGC Features API tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
 
 ### Development, aka Dev (experimental work, expected downtime)
 
@@ -28,6 +30,8 @@ Maintenance on the staging environment will be announced internally and selected
 * List collections: [https://dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
 * Raster API (tiling): [https://dev.openveda.cloud/api/raster/docs](https://dev.openveda.cloud/api/raster/docs)
 * STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](https://dev.openveda.cloud/api/stac/index.html)
+* OGC Features API collections: [https://firenrt.delta-backend.com/collections](https://firenrt.delta-backend.com/collections)
+* OGC Features API tutorial: [https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html](https://nasa-impact.github.io/veda-docs/notebooks/tutorials/mapping-fires.html)
 
 
 ## Using tile layers in external services


### PR DESCRIPTION
## Goal

Adding where the current dev / staging API and docs are for OGC Features API (currently only used by EIS Fire). Resolves a comment in https://github.com/NASA-IMPACT/veda-analytics/issues/98#issuecomment-2011967447 (that I forgot about 😬)

Production [API PR here](https://github.com/NASA-IMPACT/veda-backend/pull/346)