### PR TITLE
Fixed the links for a couple of the dev api urls

### DIFF
--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -27,8 +27,8 @@ Maintenance on the staging environment will be announced internally and selected
 * STAC browser: [veda-dev-stac-browser](https://dev.openveda.cloud/)
 * STAC API (metadata): [dev.openveda.cloud/api/stac/docs](https://dev.openveda.cloud/api/stac/docs)
 * List collections: [dev.openveda.cloud/api/stac/collections](https://dev.openveda.cloud/api/stac/collections)
-* Raster API (map tiles and timeseries): [https://dev.openveda.cloud/api/raster/docs](dev.openveda.cloud/api/raster/docs)
-* STAC viewer (experimental): [https://dev.openveda.cloud/api/stac/index.html](dev.openveda.cloud/api/stac/)
+* Raster API (map tiles and timeseries): [dev.openveda.cloud/api/raster/docs](https://dev.openveda.cloud/api/raster/docs)
+* STAC viewer (experimental): [dev.openveda.cloud/api/stac/index.html](https://dev.openveda.cloud/api/stac/index.html)
 
 ## Using tile layers in external services
 


### PR DESCRIPTION
Minor markdown adjustment in services overview: A couple of the dev api url links were not working as expected.

