### PR TITLE
fix: typo in index.qmd

### DIFF
--- a/notebooks/index.qmd
+++ b/notebooks/index.qmd
@@ -14,7 +14,7 @@ The **Quickstarts** examples are further divided into two sections, which you ca
 
 - **Accessing the Data Directly**: For when you want to access the raw data (e.g., to do a specific analysis). In this case, permissions are required to access the data (i.e., must be run on VEDA JupyterHub) and computation happens within the user's instance (i.e., the user needs to think about instance size). This approach is suitable for use within notebooks. All examples provided in this section require VEDA JupyterHub access to run. 
 
-- **Using the Raster API**: For when you want to show outputs to other people or do standard processing. No permissions required (i.e., notebooks can be run on `mybinder`). Additionally, the computation happens somehwere else (i.e., user does not have to think about instance size). Lastly, this approach is suitable for use within notebooks as well as web application frontends (e.g., like dataset discoveries). These notebook examples can be run on both VEDA JupyterHub, as well as outside of the Hub (see instructions below) and within `mybinder`.
+- **Using the Raster API**: For when you want to show outputs to other people or do standard processing. No permissions required (i.e., notebooks can be run on `mybinder`). Additionally, the computation happens somewhere else (i.e., user does not have to think about instance size). Lastly, this approach is suitable for use within notebooks as well as web application frontends (e.g., like dataset discoveries). These notebook examples can be run on both VEDA JupyterHub, as well as outside of the Hub (see instructions below) and within `mybinder`.
 
 
 ## How to run


### PR DESCRIPTION
# What this PR is

Fixes a typo within `index.qmd`: `somehwere` -> `somewhere`

![aint much but its honest work](https://i.kym-cdn.com/entries/icons/original/000/028/021/work.jpg)
