### PR TITLE
Fix: Add temporary callout warnings to inform users of url and endpoint changes

### DIFF
--- a/notebooks/index.qmd
+++ b/notebooks/index.qmd
@@ -2,6 +2,14 @@
 title: Usage Examples
 ---
 
+::: {.callout-note title="Base URL Changes"}
+The VEDA Team is in the process of updating documentation notebooks to use the new stable production APIs. Currently most notebooks use staging APIs.
+:::
+
+::: {.callout-warning title="Breaking tiling endpoint changes"} 
+VEDA tilers are being upgraded to titiler-pgstac v1 which better aligns with the stac-api spec and has many improvements but also introduces some breaking endpoint changes. The VEDA team will be updating notebooks for the new endpoints but, in the meantime, [the titiler-pgstac migration documentation](https://stac-utils.github.io/titiler-pgstac/latest/migrations/v1_migration/) provides support for using the new endpoints.
+:::
+
 ## Getting started
 The example notebooks are divided into three sections: 
 

--- a/services/apis.qmd
+++ b/services/apis.qmd
@@ -11,6 +11,14 @@ Most of the VEDA APIs are hosted out of a single project ([veda-backend](https:/
 While some of our services are already very mature, VEDA is currently in the build-up phase. Therefore, we do not yet have a production environment for users.
 Maintenance on the staging environment will be announced internally and selected known stakeholders will be informed of any larger changes.
 
+::: {.callout-note title="Base URL Changes"}
+The VEDA Team is in the process of updating documentation notebooks to use the new stable production APIs. Currently most notebooks use staging APIs.
+:::
+
+::: {.callout-warning title="Breaking tiling endpoint changes"} 
+VEDA tilers are being upgraded to titiler-pgstac v1 which better aligns with the stac-api spec and has many improvements but also introduces some breaking endpoint changes. The VEDA team will be updating notebooks for the new endpoints but, in the meantime, [the titiler-pgstac migration documentation](https://stac-utils.github.io/titiler-pgstac/latest/migrations/v1_migration/) provides support for using the new endpoints.
+:::
+
 ### Production (stable):
 * STAC browser: [veda-stac-browser](https://openveda.cloud)
 * STAC API (metadata): [https://openveda.cloud/api/stac/docs](https://openveda.cloud/api/stac/docs)


### PR DESCRIPTION
## Description
This PR adds temporary callout warnings to API and Usage Example overviews to inform users that 
1. API urls are changing (to production openveda.cloud endpoints)
2. Notebook examples will be updated after breaking changes are introduced by updating tiling dependencies

## What type of example is this?
**N/A**
_Choose one of the following and delete the rest ([read more](https://nasa-impact.github.io/veda-docs/notebooks))_

Quickstart: Accessing the Data Directly
Quickstart: Using the Raster API
Tutorial
Dataset

## Checklist
_The following checklist ensures that our notebooks are internally consistent ([read more](https://nasa-impact.github.io/veda-docs/contributing/doc-and-notebooks))_

**N/A no notebook changes but quarto preview rendered locally**

- [ ] The first cell contains the rendering information with author and data
- [ ] The notebook has a **Run this Notebook** section (with filename in link)
- [ ] The notebook has an **Approach** section
- [ ] All the packages that are imported in the notebooks are used within the notebook
- [ ] Any complex geometries are accessed from remote storage
- [ ] Each code cell comes after a markdown cell containing explantory text
- [ ] All cells in the notebook book have been run in order with a fresh kernel (cell numbers should be 1, 2, 3, 4, ...)
- [ ] If the example type is **Dataset** the filename is `<collection_id>.ipynb`
