### PR TITLE
Update notebook contributing templates for prod apis and dependency changes

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -72,7 +72,10 @@ website:
               - notebooks/datasets/air-quality-covid.ipynb
       - section: contributing/index.qmd
         contents:
-          - contributing/docs-and-notebooks.qmd
+          - section: contributing/docs-and-notebooks.qmd
+            contents:
+              - notebooks/templates/template-accessing-the-data-directly.ipynb
+              - notebooks/templates/template-using-the-raster-api.ipynb
           - section: contributing/dataset-ingestion/index.qmd
             contents:
               - contributing/dataset-ingestion/file-preparation.qmd

--- a/contributing/docs-and-notebooks.qmd
+++ b/contributing/docs-and-notebooks.qmd
@@ -14,7 +14,11 @@ Please note that this documentation site is rendered using [Quarto](https://quar
 
 ## Notebook Author Guidelines
 
-There are two template notebooks in this directory titled: `template-using-the-raster-api.ipynb` and `template-accessing-the-data-directly.ipynb` that you can use as a starting place. Alternatively you can pull specific cells from that notebook into your own.
+There are two template notebooks in this section that you can use as a starting place. Alternatively you can pull specific cells from that notebook into your own.
+
+ * [Using the raster API: `template-using-the-raster-api.ipynb`](/notebooks/templates/template-using-the-raster-api.ipynb)
+
+ * [Accessing the data directly: `template-accessing-the-data-directly.ipynb`](/notebooks/templates/template-accessing-the-data-directly.ipynb) 
 
 
 ### Style

--- a/notebooks/templates/template-accessing-the-data-directly.ipynb
+++ b/notebooks/templates/template-accessing-the-data-directly.ipynb
@@ -308,11 +308,7 @@
    "source": [
     "# This is a workaround that is planning to move up into stackstac itself\n",
     "import rasterio as rio\n",
-    "import boto3\n",
-    "\n",
-    "gdal_env = stackstac.DEFAULT_GDAL_ENV.updated(\n",
-    "    always=dict(AWS_NO_SIGN_REQUEST=False, session=rio.session.AWSSession(boto3.Session()))\n",
-    ")"
+    "import boto3"
    ]
   },
   {
@@ -323,7 +319,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "da = stackstac.stack(search.item_collection(), gdal_env=gdal_env)\n",
+    "da = stackstac.stack(search.item_collection())\n",
     "da"
    ]
   },

--- a/notebooks/templates/template-accessing-the-data-directly.ipynb
+++ b/notebooks/templates/template-accessing-the-data-directly.ipynb
@@ -13,14 +13,19 @@
   {
    "cell_type": "raw",
    "id": "c7ab74b2-f3b9-4326-a655-70e8df9f1261",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
    "source": [
     "---\n",
-    "title: \n",
+    "title: Template (Accessing data directly)\n",
     "description: \n",
     "author: \n",
     "date: Month day, year\n",
     "execute:\n",
+    "  cache: true\n",
     "  freeze: true\n",
     "---"
    ]
@@ -131,8 +136,8 @@
     "You can discover available collections the following ways:\n",
     "\n",
     "* Programmatically: see example in the `list-collections.ipynb` notebook\n",
-    "* JSON API: https://staging-stac.delta-backend.com/collections\n",
-    "* STAC Browser: http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com"
+    "* JSON API: https://openveda.cloud/api/stac/collections\n",
+    "* STAC Browser: http://openveda.cloud"
    ]
   },
   {
@@ -142,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "STAC_API_URL = \"https://staging-stac.delta-backend.com\"\n",
+    "STAC_API_URL = \"https://openveda.cloud/api/stac\"\n",
     "\n",
     "collection_id = "
    ]
@@ -176,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bbox = []\n",
+    "bbox = [-180.0, -90.0, 180.0, 90.0]\n",
     "datetime = \"2000-01-01/2022-01-02\""
    ]
   },
@@ -306,7 +311,7 @@
     "import boto3\n",
     "\n",
     "gdal_env = stackstac.DEFAULT_GDAL_ENV.updated(\n",
-    "    always=dict(AWS_NO_SIGN_REQUEST=True, session=rio.session.AWSSession(boto3.Session())\n",
+    "    always=dict(AWS_NO_SIGN_REQUEST=False, session=rio.session.AWSSession(boto3.Session()))\n",
     ")"
    ]
   },
@@ -317,8 +322,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
     "da = stackstac.stack(search.item_collection(), gdal_env=gdal_env)\n",
-    "da = da.assign_coords({\"time\": pd.to_datetime(da.start_datetime)})\n",
     "da"
    ]
   },
@@ -337,7 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subset = da.rio.clip([aoi[\"geometry\"]])\n",
+    "subset = da.clip([aoi[\"geometry\"]])\n",
     "subset"
    ]
   },

--- a/notebooks/templates/template-using-the-raster-api.ipynb
+++ b/notebooks/templates/template-using-the-raster-api.ipynb
@@ -13,14 +13,19 @@
   {
    "cell_type": "raw",
    "id": "c7ab74b2-f3b9-4326-a655-70e8df9f1261",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
    "source": [
     "---\n",
-    "title: \n",
+    "title: Template (Using the raster API)\n",
     "description: \n",
     "author: \n",
     "date: Month day, year\n",
     "execute:\n",
+    "  cache: true\n",
     "  freeze: true\n",
     "---"
    ]
@@ -110,8 +115,8 @@
     "You can discover available collections the following ways:\n",
     "\n",
     "* Programmatically: see example in the `list-collections.ipynb` notebook\n",
-    "* JSON API: https://staging-stac.delta-backend.com/collections\n",
-    "* STAC Browser: http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com"
+    "* JSON API: https://openveda.cloud/api/stac/collections\n",
+    "* STAC Browser: http://openveda.cloud"
    ]
   },
   {
@@ -121,8 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "STAC_API_URL = \"https://staging-stac.delta-backend.com\"\n",
-    "RASTER_API_URL = \"https://staging-raster.delta-backend.com\"\n",
+    "STAC_API_URL = \"https://openveda.cloud/api/stac\"\n",
+    "RASTER_API_URL = \"https://openveda.cloud/api/raster\"\n",
     "\n",
     "collection_id = "
    ]
@@ -289,9 +294,30 @@
     "tags": []
    },
    "source": [
-    "## Use `/stac/tilejson.json` to get tiles\n",
+    "## Use the STAC Item to get tiles with the RASTER API\n",
     "\n",
-    "We pass the item_id, collection id, and the `rescale_values` in to the RASTER API endpoint and get back a tile."
+    "We pass the item_id, collection id, and `rescale_values` in to the RASTER API `/collections/{collection_id}/items/{item_id}/tilejson.json` endpoint and get back a tile. See the tips below for choosing visualization parameters for your tiles.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Colormap Tip:</b>\n",
+    "    <br/>Find the list of available colormaps at <code>{RASTER_API}/colorMaps</code> \n",
+    "    (<a href=https://openveda.cloud/api/raster/colorMaps>openveda.cloud/api/raster/colorMaps</a>) \n",
+    "    and get colormap metadata and/or legend image at \n",
+    "<code>{RASTER_API}/colorMaps/{colorMapName}</code> (See docs at <a href=https://openveda.cloud/api/raster/docs#/ColorMaps/getColorMap>openveda.cloud/api/raster/docs#/ColorMaps/getColorMap</a>)\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Tiling schemes Tip:</b>\n",
+    "    <br/>Find the list of available tile matrix set ids at <code>{RASTER_API}/tileMatrixSets</code> \n",
+    "(<a href=https://openveda.cloud/api/raster/tileMatrixSets>openveda.cloud/api/raster/tileMatrixSets</a>) and get tiling scheme metadata at <code>{RASTER_API}/colorMaps/{colorMapName}</code> (See docs at <a href=https://openveda.cloud/api/raster/docs#/tileMatrixSets/tileMatrixSetId>openveda.cloud/api/raster/docs#/tileMatrixSets/tileMatrixSetId</a>)\n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Raster rescale range tip:</b>\n",
+    "    <br/>Get the statistics for item assets at <code>{RASTER_API}/collections/{collection_id/items/{item_id}/statistics</code> \n",
+    "    (<a href=https://openveda.cloud/api/raster/docs#/STAC%20Item/statistics_collections__collection_id__items__item_id__statistics_get</a>)\n",
+    "</div>\n"
    ]
   },
   {
@@ -301,13 +327,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rescale_values = collection[\"summaries\"][\"cog_default\"]\n",
+    "# Start with the first item returned\n",
+    "item = items[0]\n",
+    "\n",
+    "# Here is a default tile matrix id\n",
+    "tile_matrix_set_id = \"WebMercatorQuad\"\n",
+    "\n",
+    "# Adjust these values to find the ideal range for the range of data you will be visualizing\n",
+    "rescale_min = 0\n",
+    "rescale_max = 1\n",
+    "\n",
+    "# Set the asset key you want to visualize (many STAC Items in the VEDA catalog have a cog_default assets)\n",
+    "asset_key = \"cog_default\"\n",
+    "\n",
+    "# Choose a colormap\n",
+    "colormap_name = \"viridis\"\n",
+    "\n",
+    "# Use stac item url with to get tilejson from raster api\n",
+    "url = f\"{RASTER_API_URL}/collections/{collection_id}/items/{item['id']}/{tile_matrix_set_id}/tilejson.json\"\n",
     "\n",
     "tiles = requests.get(\n",
-    "    f\"{RASTER_API_URL}/stac/tilejson.json?collection={collection_id}&item={item['id']}\"\n",
-    "    \"&assets=cog_default\"\n",
-    "    \"&color_formula=gamma+r+1.05&colormap_name=rdbu_r\"\n",
-    "    f\"&rescale={rescale_values['min']},{rescale_values['max']}\",\n",
+    "    url,\n",
+    "    params = {\n",
+    "        \"assets\": asset_key,\n",
+    "        \"colormap_name\": colormap_name,\n",
+    "        \"rescale\": f\"{rescale_min},{rescale_max}\"\n",
+    "    }\n",
     ").json()\n",
     "tiles"
    ]
@@ -350,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What
- Explicitly add templates for contributing notebooks to the sidebar in the contributing section
- Update veda urls to stable production urls
- Refresh all cells to run on the current jupyterhub server
- Add support for using the upgraded titiler-pgstac

## How tested
I copied each of these templates to jupyterhub and ran all cells for existing collections in openveda.cloud
