### PR TITLE
Fix index and remove AGU announcement

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -50,7 +50,7 @@ website:
               - nasa-veda-platform/scientific-computing/code-server.md
               - nasa-veda-platform/scientific-computing/ssh.md
               - nasa-veda-platform/scientific-computing/github-authentication.qmd
-              - nasa-veda-platform/getting-access.qmd
+              - nasa-veda-platform/scientific-computing/getting-access.qmd
       - text: "---"
       - section: instance-management/index.qmd
         contents:
@@ -120,12 +120,6 @@ website:
           - open-source-ecosystem/architecture.qmd
           - open-source-ecosystem/repositories.qmd
           - open-source-ecosystem/external-resources.qmd
-  announcement: 
-    icon: info-circle
-    dismissable: true
-    content: "**AGU2024:** Find VEDA at the AGU General Meeting 2024 on December 9-13 in Washington DC with [these presentations](AGU2024.qmd)."
-    type: primary
-    position: below-navbar
 format:
   html:
     theme:


### PR DESCRIPTION
Fixes a broken link in the index and removes the AGU event banner since it has ended.
