### PR TITLE
fix: Fix Derechos side bar navigation #240

### DIFF
--- a/user-guide/notebooks/stories/derechos.ipynb
+++ b/user-guide/notebooks/stories/derechos.ipynb
@@ -62,12 +62,12 @@
    "id": "6bf5f134-0fba-41bf-8d1d-7654a1b9307a",
    "metadata": {},
    "source": [
-    "## Example scripts to process and visualize information"
+    "## Environment Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a6041ba0-3d38-433d-8982-505de8e6fbaf",
    "metadata": {},
    "outputs": [],
@@ -75,18 +75,17 @@
     "# Load libraries\n",
     "#!pip install -q earthaccess pandas xarray fsspec requests pystac_client\n",
     "\n",
-    "import earthaccess\n",
-    "from earthaccess import Auth, Store\n",
-    "from pystac_client import Client\n",
     "import datetime\n",
+    "import glob\n",
+    "import os\n",
+    "\n",
+    "import earthaccess\n",
     "import pandas as pd\n",
-    "import xarray as xr\n",
-    "import fsspec\n",
+    "import plotutils as putils\n",
     "import requests\n",
-    "import json\n",
-    "\n",
-    "\n",
-    "import plotutils as putils"
+    "import xarray as xr\n",
+    "from earthaccess import Store\n",
+    "from pystac_client import Client"
    ]
   },
   {
@@ -96,8 +95,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#For retrieving data already catalogued in VEDA STAC\n",
-    "STAC_API_URL=\"https://openveda.cloud/api/stac\"\n",
+    "# For retrieving data already catalogued in VEDA STAC\n",
+    "STAC_API_URL = \"https://openveda.cloud/api/stac\"\n",
     "RASTER_API_URL = \"https://openveda.cloud/api/raster\""
    ]
   },
@@ -129,10 +128,10 @@
    "id": "9c225b07-7ecc-462d-a19a-ce15187238e5",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h1><strong>Example:</strong> Retrieve GLDAS data from EarthData portal</h1>\n",
-    "<h3>Global Land Data Assimilation System (GLDAS) data helps assess soil moisture levels before and after the storm, showing how pre-existing drought conditions contributed to dust transport and how heavy rainfall may have impacted runoff and flooding.</h3>\n",
-    "</div>\n"
+    "\n",
+    "# Example: Soil Moisture from GLDAS\n",
+    "\n",
+    "Retrieve Global Land Data Assimilation System (GLDAS) data from the NASA EarthData portal. GLDAS data helps assess soil moisture levels before and after the storm, showing how pre-existing drought conditions contributed to dust transport and how heavy rainfall may have impacted runoff and flooding."
    ]
   },
   {
@@ -174,7 +173,7 @@
    "id": "90b58cb3-206c-43cd-9fdd-9bb410a6839e",
    "metadata": {},
    "source": [
-    "### Select dates and find Earthdata links"
+    "## Select dates and find links"
    ]
   },
   {
@@ -756,20 +755,20 @@
     "# ── Search by date ────────(requires >2GB RAM if more than 40 dates are selected)───────────────\n",
     "start_date = datetime.datetime(2022, 4, 1)\n",
     "end_date = datetime.datetime(2022, 5, 12)\n",
-    "date_array = pd.date_range(start=start_date, end=end_date, freq='D').to_pydatetime()\n",
+    "date_array = pd.date_range(start=start_date, end=end_date, freq=\"D\").to_pydatetime()\n",
     "\n",
     "# ── Dataset ─────────────────────────────────────────────────────────────────────────────────────\n",
-    "short_name=\"GLDAS_NOAH025_3H\"\n",
-    "version=\"2.1\"\n",
-    "variable = 'SoilMoi0_10cm_inst' #Only select a single variable of interest\n",
+    "short_name = \"GLDAS_NOAH025_3H\"\n",
+    "version = \"2.1\"\n",
+    "variable = \"SoilMoi0_10cm_inst\"  # Only select a single variable of interest\n",
     "\n",
     "# get all granules\n",
-    "print('Retrieving data granules from Earthaccess') \n",
+    "print(\"Retrieving data granules from Earthaccess\")\n",
     "results = earthaccess.search_data(\n",
-    "   short_name=short_name,\n",
-    "   version=version,\n",
-    "   temporal=(start_date, end_date),\n",
-    "   cloud_hosted=True\n",
+    "    short_name=short_name,\n",
+    "    version=version,\n",
+    "    temporal=(start_date, end_date),\n",
+    "    cloud_hosted=True,\n",
     ")\n",
     "\n",
     "# grab the S3 URLs\n",
@@ -777,17 +776,17 @@
     "print(f\"Found {len(urls)} files\")\n",
     "\n",
     "# ── Open granules ───────────────────────────────────────────────────────────────────────────────\n",
-    "granules=earthaccess.open(results)\n",
-    "fs = earthaccess.get_s3_filesystem(results=results)   # auto‐picks the right DAAC & creds\n",
+    "granules = earthaccess.open(results)\n",
+    "fs = earthaccess.get_s3_filesystem(results=results)  # auto‐picks the right DAAC & creds\n",
     "\n",
-    "fsspec_caching = {\n",
-    "    \"cache_type\": \"mmap\"\n",
-    "}\n",
-    "lat_range=slice(24, 50)\n",
-    "lon_range=slice(-125, -66)\n",
+    "fsspec_caching = {\"cache_type\": \"mmap\"}\n",
+    "lat_range = slice(24, 50)\n",
+    "lon_range = slice(-125, -66)\n",
+    "\n",
     "\n",
     "def subset(ds):\n",
     "    return ds[[variable]].sel(lat=lat_range, lon=lon_range)\n",
+    "\n",
     "\n",
     "ds = xr.open_mfdataset(\n",
     "    [fs.open(url, **fsspec_caching) for url in urls],\n",
@@ -803,7 +802,7 @@
     ")\n",
     "\n",
     "# ── Compute Daily Mean ───────────────────────────────────────────────────────────────────────────────\n",
-    "ds_resampled = ds.resample(time=\"1D\").mean(dim='time').compute()\n",
+    "ds_resampled = ds.resample(time=\"1D\").mean(dim=\"time\").compute()\n",
     "ds_resampled"
    ]
   },
@@ -812,7 +811,7 @@
    "id": "568bf7d8-6520-47db-838b-029c63947708",
    "metadata": {},
    "source": [
-    "### Create interactive geospatial folium plot"
+    "## Create interactive map"
    ]
   },
   {
@@ -988,17 +987,19 @@
    ],
    "source": [
     "# Use the plot_folium_from_xarray function from plotutils\n",
-    "putils.plot_folium_from_xarray(dataset=ds_resampled['SoilMoi0_10cm_inst'],\n",
-    "                  day_select='2022-05-11',\n",
-    "                  bbox=[-130, 33, -90, 50],\n",
-    "                  var_name_for_title='Soil Moisture from GLDAS (m³/m³) [subset]',\n",
-    "                  matplot_ramp = 'YlOrRd_r',\n",
-    "                  zoom_level = 4.5,\n",
-    "                  flipud=False,\n",
-    "                  save_tif=False,\n",
-    "                  tif_filename=None,\n",
-    "                  crs = '4326',\n",
-    "                  opacity = 0.8)"
+    "putils.plot_folium_from_xarray(\n",
+    "    dataset=ds_resampled[\"SoilMoi0_10cm_inst\"],\n",
+    "    day_select=\"2022-05-11\",\n",
+    "    bbox=[-130, 33, -90, 50],\n",
+    "    var_name_for_title=\"Soil Moisture from GLDAS (m³/m³) [subset]\",\n",
+    "    matplot_ramp=\"YlOrRd_r\",\n",
+    "    zoom_level=4.5,\n",
+    "    flipud=False,\n",
+    "    save_tif=False,\n",
+    "    tif_filename=None,\n",
+    "    crs=\"4326\",\n",
+    "    opacity=0.8,\n",
+    ")"
    ]
   },
   {
@@ -1006,7 +1007,7 @@
    "id": "0e06456e-bfe6-4e43-ae7a-d56aba746c91",
    "metadata": {},
    "source": [
-    "### Create a gif over the date range"
+    "## Create a animation over dates"
    ]
   },
   {
@@ -1035,11 +1036,13 @@
    ],
    "source": [
     "# Usage:\n",
-    "putils.matplotlib_gif(data=ds_resampled['SoilMoi0_10cm_inst'],\n",
-    "               bbox= [-130, 33, -90, 50],\n",
-    "               gif_savename= \"soil_matplotlib.gif\",\n",
-    "               duration=2,\n",
-    "               cmap=\"YlOrRd_r\")"
+    "putils.matplotlib_gif(\n",
+    "    data=ds_resampled[\"SoilMoi0_10cm_inst\"],\n",
+    "    bbox=[-130, 33, -90, 50],\n",
+    "    gif_savename=\"soil_matplotlib.gif\",\n",
+    "    duration=2,\n",
+    "    cmap=\"YlOrRd_r\",\n",
+    ")"
    ]
   },
   {
@@ -1047,13 +1050,11 @@
    "id": "d1865289-78ef-4d0e-8371-6172c746c883",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Pull WLDAS soil moisture data from the VEDA STAC catalog and visualize.</h2>\n",
-    "\n",
-    "The Western Land Data Assimilation System (WLDAS) is a regional instance of NASA’s Land Information System (LIS), developed at Goddard Space Flight Center for the western United States.  It integrates meteorological forcings (precipitation, radiation, temperature, humidity, wind, surface pressure) and satellite-derived parameters (vegetation class, soil texture, elevation) into the Noah-MP land surface model using data assimilation techniques.\n",
+    "# Example: Soil moisture data from WLDAS\n",
+    "This example pulls soil moisture data from the Western Land Data Assimilation System (WLDAS) via the VEDA STAC catalog and visualize.The WLDAS is a regional instance of NASA’s Land Information System (LIS), developed at Goddard Space Flight Center for the western United States.  It integrates meteorological forcings (precipitation, radiation, temperature, humidity, wind, surface pressure) and satellite-derived parameters (vegetation class, soil texture, elevation) into the Noah-MP land surface model using data assimilation techniques.\n",
     "\n",
     "Soil moisture critically controls the partitioning of net surface energy into latent (evapotranspiration) versus sensible (heating) fluxes. Wetter soils favor latent heat, stabilizing the boundary layer, whereas drier soils boost sensible heating, enhancing near-surface temperature and convective available potential energy (CAPE). These processes govern where and when thunderstorms can initiate and organize.\n",
-    "</div>\n"
+    "\n"
    ]
   },
   {
@@ -1061,7 +1062,7 @@
    "id": "5b770e10-fcd9-4fa5-8eaf-a5feb6390064",
    "metadata": {},
    "source": [
-    "### Processing steps:\n",
+    "## Processing steps:\n",
     "1.) Choose STAC catalog ID and date<br />\n",
     "2.) Retrieve collection information and items from VEDA STAC catalog<br />\n",
     "3.) Retrieve item statistics and tiling information<br />\n",
@@ -1073,7 +1074,7 @@
    "id": "69c58d56-338b-4c04-a670-285aabe2ef2d",
    "metadata": {},
    "source": [
-    "### Choose variable and retrieve json from VEDA STAC catalogue"
+    "## Choose variable and retrieve json from VEDA STAC catalogue"
    ]
   },
   {
@@ -2009,10 +2010,10 @@
     }
    ],
    "source": [
-    "#TODO: Change collection_ID and date\n",
+    "# TODO: Change collection_ID and date\n",
     "client_STAC = Client.open(STAC_API_URL)\n",
     "\n",
-    "collection_id = 'wldas-derecho-sm'\n",
+    "collection_id = \"wldas-derecho-sm\"\n",
     "date = \"2022-05-11\"\n",
     "\n",
     "results = client_STAC.search(collections=[collection_id], datetime=date)\n",
@@ -2027,10 +2028,10 @@
     "# grab the dashboard render block\n",
     "dashboard_render = collection.extra_fields[\"renders\"][\"dashboard\"]\n",
     "\n",
-    "assets = dashboard_render['assets'][0]\n",
-    "(vmin, vmax), = dashboard_render[\"rescale\"]\n",
+    "assets = dashboard_render[\"assets\"][0]\n",
+    "((vmin, vmax),) = dashboard_render[\"rescale\"]\n",
     "\n",
-    "collection\n"
+    "collection"
    ]
   },
   {
@@ -2038,7 +2039,7 @@
    "id": "47a8ce62-0d57-40b5-a0a2-550efece7ca0",
    "metadata": {},
    "source": [
-    "### Retrieve tiling information"
+    "## Retrieve tiling information"
    ]
   },
   {
@@ -2071,7 +2072,7 @@
     "response.raise_for_status()\n",
     "\n",
     "tiles = response.json()\n",
-    "print(tiles)\n"
+    "print(tiles)"
    ]
   },
   {
@@ -2079,7 +2080,7 @@
    "id": "3ccda185-72b9-4137-b7c9-9d97edcc9271",
    "metadata": {},
    "source": [
-    "### Plot data"
+    "## Plot data"
    ]
   },
   {
@@ -2269,19 +2270,19 @@
    "source": [
     "# Use the new plot_folium_from_VEDA_STAC function\n",
     "m = putils.plot_folium_from_VEDA_STAC(\n",
-    "    tiles_url_template=tiles['tiles'][0],\n",
+    "    tiles_url_template=tiles[\"tiles\"][0],\n",
     "    center_coords=[41.5, -110],\n",
     "    zoom_level=5,\n",
-    "    rescale=(vmin,vmax),\n",
+    "    rescale=(vmin, vmax),\n",
     "    colormap_name=colormap_name,\n",
-    "    capitalize_cmap=False,  #to better match VEDA colors and matplotlib colors\n",
+    "    capitalize_cmap=False,  # to better match VEDA colors and matplotlib colors\n",
     "    layer_name=\"WLDAS soil moisture\",\n",
-    "    date=f'{date}T00:00:00Z',\n",
+    "    date=f\"{date}T00:00:00Z\",\n",
     "    colorbar_caption=\"Soil Moisture (m3/m3)\",\n",
-    "    attribution='VEDA WLDAS Soil Moisture',\n",
-    "    tile_name='WLDAS Soil Moisture Data',\n",
+    "    attribution=\"VEDA WLDAS Soil Moisture\",\n",
+    "    tile_name=\"WLDAS Soil Moisture Data\",\n",
     "    opacity=0.8,\n",
-    "    height =  \"800px\"\n",
+    "    height=\"800px\",\n",
     ")\n",
     "\n",
     "# Display the map\n",
@@ -2293,13 +2294,12 @@
    "id": "a3e5f5d3-5aab-45d4-93ac-1e9f0ebc5a9c",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Retrieve MERRA-2 hourly files for Aerosol Optical Thickness</h2>\n",
+    "# Example:  Hourly Aerosol Optical Thickness from MERRA-2\n",
     "\n",
-    "Aerosol Optical Thickness (AOT), also called Aerosol Optical Depth (AOD), is a dimensionless measure of how much sunlight aerosols—tiny particles like dust, smoke or sea salt—scatter and absorb as it travels through a column of atmosphere. In practical terms, an AOT of 0.1 means only 10 % of the direct solar beam is extinguished by aerosols before reaching the surface.\n",
+    "This example retrieves MERRA-2 hourly files for Aerosol Optical Thickness. Aerosol Optical Thickness (AOT), also called Aerosol Optical Depth (AOD), is a dimensionless measure of how much sunlight aerosols—tiny particles like dust, smoke or sea salt—scatter and absorb as it travels through a column of atmosphere. In practical terms, an AOT of 0.1 means only 10 % of the direct solar beam is extinguished by aerosols before reaching the surface.\n",
     "\n",
     "The intense straight-line winds in derechos can uplift large quantities of soil and dust, dramatically increasing AOT downwind. Tracking AOT in near-real-time reveals the spatial extent and intensity of these airborne dust plumes.\n",
-    "</div>\n"
+    "\n"
    ]
   },
   {
@@ -2307,7 +2307,7 @@
    "id": "c4851cb9-1d4c-4a4b-a5da-68fa9df5f13c",
    "metadata": {},
    "source": [
-    "### Processing steps:\n",
+    "## Processing steps:\n",
     "1.) Select a start and end date for the data granules<br />\n",
     "2.) Add <a href=\"https://search.earthdata.nasa.gov/search/granules/collection-details?p=C1276812830-GES_DISC&pg[0][v]=f&pg[0][gsk]=-start_date&q=merra%20aerosol&tl=1031468010.052!5!!\"\n",
     "        target=\"_blank\" rel=\"noopener noreferrer\"\n",
@@ -2326,7 +2326,7 @@
    "id": "e89209ab-752a-473f-922c-67d9ecd38712",
    "metadata": {},
    "source": [
-    "### Select and filter"
+    "## Select and filter"
    ]
   },
   {
@@ -2954,20 +2954,20 @@
     "# ── Search by date ──────────────────────────────────────────────────────────────────────────────\n",
     "start_date = datetime.datetime(2022, 5, 12)\n",
     "end_date = datetime.datetime(2022, 5, 12)\n",
-    "date_array = pd.date_range(start=start_date, end=end_date, freq='D').to_pydatetime()\n",
+    "date_array = pd.date_range(start=start_date, end=end_date, freq=\"D\").to_pydatetime()\n",
     "\n",
     "# ── Dataset ─────────────────────────────────────────────────────────────────────────────────────\n",
-    "short_name=\"M2T1NXAER\"\n",
-    "version=\"5.12.4\"\n",
-    "variable = 'TOTEXTTAU' #Total aerosol extinction optical thickness\n",
+    "short_name = \"M2T1NXAER\"\n",
+    "version = \"5.12.4\"\n",
+    "variable = \"TOTEXTTAU\"  # Total aerosol extinction optical thickness\n",
     "\n",
     "# get all granules\n",
-    "print('Retrieving data granules from Earthaccess') \n",
+    "print(\"Retrieving data granules from Earthaccess\")\n",
     "results = earthaccess.search_data(\n",
-    "   short_name=short_name,\n",
-    "   version=version,\n",
-    "   temporal=(start_date, end_date),\n",
-    "   cloud_hosted=True\n",
+    "    short_name=short_name,\n",
+    "    version=version,\n",
+    "    temporal=(start_date, end_date),\n",
+    "    cloud_hosted=True,\n",
     ")\n",
     "\n",
     "# grab the S3 URLs\n",
@@ -2975,17 +2975,17 @@
     "print(f\"Found {len(urls)} files\")\n",
     "\n",
     "# ── Open granules ───────────────────────────────────────────────────────────────────────────────\n",
-    "granules=earthaccess.open(results)\n",
-    "fs = earthaccess.get_s3_filesystem(results=results)   # auto‐picks the right DAAC & creds\n",
+    "granules = earthaccess.open(results)\n",
+    "fs = earthaccess.get_s3_filesystem(results=results)  # auto‐picks the right DAAC & creds\n",
     "\n",
-    "fsspec_caching = {\n",
-    "    \"cache_type\": \"mmap\"\n",
-    "}\n",
-    "lat_range=slice(24, 50)\n",
-    "lon_range=slice(-125, -66)\n",
+    "fsspec_caching = {\"cache_type\": \"mmap\"}\n",
+    "lat_range = slice(24, 50)\n",
+    "lon_range = slice(-125, -66)\n",
+    "\n",
     "\n",
     "def subset(ds):\n",
     "    return ds[[variable]].sel(lat=lat_range, lon=lon_range)\n",
+    "\n",
     "\n",
     "ds = xr.open_mfdataset(\n",
     "    [fs.open(url, **fsspec_caching) for url in urls],\n",
@@ -3008,7 +3008,9 @@
    "id": "b0f2746c-b6e2-4b8b-a6d4-2e530c6462d0",
    "metadata": {},
    "source": [
-    "## Open the MERRA file and plot by hour in a .gif for the selected variable AOT"
+    "## Plot time series of Aerosols\n",
+    "\n",
+    "Open the MERRA file and plot by hour in a .gif for the selected variable AOT"
    ]
   },
   {
@@ -3037,11 +3039,13 @@
    ],
    "source": [
     "# Use the matplotlib_gif function from plotutils\n",
-    "putils.matplotlib_gif(data=ds['TOTEXTTAU'],\n",
-    "               bbox= [-130, 33, -90, 50],\n",
-    "               gif_savename= \"merra_aot.gif\",\n",
-    "               duration=2,\n",
-    "               cmap=\"YlOrRd_r\");"
+    "putils.matplotlib_gif(\n",
+    "    data=ds[\"TOTEXTTAU\"],\n",
+    "    bbox=[-130, 33, -90, 50],\n",
+    "    gif_savename=\"merra_aot.gif\",\n",
+    "    duration=2,\n",
+    "    cmap=\"YlOrRd_r\",\n",
+    ");"
    ]
   },
   {
@@ -3049,9 +3053,9 @@
    "id": "9bb134f2-47c7-4403-8925-067633fc6226",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Pull MODIS Aerosol Optical Depth data from the VEDA STAC catalog and visualize</h2>\n",
-    "</div>\n"
+    "# Example: Aerosol Optical Depth with MODIS\n",
+    "\n",
+    "Pull MODIS Aerosol Optical Depth data from the VEDA STAC catalog and visualize\n"
    ]
   },
   {
@@ -3966,7 +3970,7 @@
     }
    ],
    "source": [
-    "collection_id = 'modis-derecho'\n",
+    "collection_id = \"modis-derecho\"\n",
     "date = \"2022-05-12\"\n",
     "\n",
     "results = client_STAC.search(collections=[collection_id], datetime=date)\n",
@@ -3981,10 +3985,10 @@
     "# grab the dashboard render block\n",
     "dashboard_render = collection.extra_fields[\"renders\"][\"dashboard\"]\n",
     "\n",
-    "assets = dashboard_render['assets'][0]\n",
-    "(vmin, vmax), = dashboard_render[\"rescale\"]\n",
+    "assets = dashboard_render[\"assets\"][0]\n",
+    "((vmin, vmax),) = dashboard_render[\"rescale\"]\n",
     "\n",
-    "collection\n"
+    "collection"
    ]
   },
   {
@@ -4207,18 +4211,18 @@
    "source": [
     "# Use the new plot_folium_from_VEDA_STAC function\n",
     "m = putils.plot_folium_from_VEDA_STAC(\n",
-    "    tiles_url_template=tiles['tiles'][0],\n",
+    "    tiles_url_template=tiles[\"tiles\"][0],\n",
     "    center_coords=[42.5, -96],\n",
     "    zoom_level=7,\n",
-    "    rescale=(vmin,vmax),\n",
+    "    rescale=(vmin, vmax),\n",
     "    colormap_name=colormap_name,\n",
     "    layer_name=\"MODIS AOD\",\n",
-    "    date=f'{date}T00:00:00Z',\n",
+    "    date=f\"{date}T00:00:00Z\",\n",
     "    colorbar_caption=\"Aerosol Optical Depth\",\n",
-    "    attribution='VEDA MODIS AOD',\n",
-    "    tile_name='MODIS AOD',\n",
+    "    attribution=\"VEDA MODIS AOD\",\n",
+    "    tile_name=\"MODIS AOD\",\n",
     "    opacity=0.8,\n",
-    "    height =  \"800px\"\n",
+    "    height=\"800px\",\n",
     ")\n",
     "\n",
     "# Display the map\n",
@@ -4230,14 +4234,11 @@
    "id": "8af64d82-ae4b-4658-8fcf-ef7e7b246d81",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Pull NCEI interpolated wind gusts data from the VEDA STAC catalog and visualize.</h2>\n",
-    "    \n",
-    "The NCEI Interpolated Wind Gusts product takes the discrete station‐reported peak wind gusts from the NCEI Storm Events Database—a standardized archive of severe‐weather observations dating back to 1950—and uses spatial interpolation to generate a continuous gridded field of maximum gust speeds across the derecho swath. \n",
+    "# Example: Wind Gusts\n",
     "\n",
-    "By filling in the gaps between point measurements, it reveals the full geographic extent and intensity gradients of the derecho’s outflow winds, often uncovering zones of extreme gust (e.g., 70 mph +) that lie between and beyond individual station sites. \n",
+    "This examples pulls data the National Centers for Environmental Information's (NCEI) Interpolated Wind Gusts data from the VEDA STAC catalog and visualizes. The NCEI Interpolated Wind Gusts product takes the discrete station‐reported peak wind gusts from the NCEI Storm Events Database—a standardized archive of severe‐weather observations dating back to 1950—and uses spatial interpolation to generate a continuous gridded field of maximum gust speeds across the derecho swath. \n",
     "\n",
-    "</div>\n"
+    "By filling in the gaps between point measurements, it reveals the full geographic extent and intensity gradients of the derecho’s outflow winds, often uncovering zones of extreme gust (e.g., 70 mph +) that lie between and beyond individual station sites. "
    ]
   },
   {
@@ -5161,7 +5162,7 @@
     }
    ],
    "source": [
-    "collection_id = 'windgusts-derecho'\n",
+    "collection_id = \"windgusts-derecho\"\n",
     "date = \"2022-05-12\"\n",
     "\n",
     "results = client_STAC.search(collections=[collection_id], datetime=date)\n",
@@ -5176,10 +5177,10 @@
     "# grab the dashboard render block\n",
     "dashboard_render = collection.extra_fields[\"renders\"][\"dashboard\"]\n",
     "\n",
-    "assets = dashboard_render['assets'][0]\n",
-    "(vmin, vmax), = dashboard_render[\"rescale\"]\n",
+    "assets = dashboard_render[\"assets\"][0]\n",
+    "((vmin, vmax),) = dashboard_render[\"rescale\"]\n",
     "\n",
-    "collection\n"
+    "collection"
    ]
   },
   {
@@ -5402,19 +5403,19 @@
    "source": [
     "# Use the new plot_folium_from_VEDA_STAC function\n",
     "m = putils.plot_folium_from_VEDA_STAC(\n",
-    "    tiles_url_template=tiles['tiles'][0],\n",
+    "    tiles_url_template=tiles[\"tiles\"][0],\n",
     "    center_coords=[45, -97.7],\n",
     "    zoom_level=6,\n",
-    "    rescale=(vmin,vmax),\n",
+    "    rescale=(vmin, vmax),\n",
     "    colormap_name=colormap_name,\n",
-    "    capitalize_cmap=False,  #to better match VEDA colors and matplotlib colors\n",
+    "    capitalize_cmap=False,  # to better match VEDA colors and matplotlib colors\n",
     "    layer_name=\"Wind Gusts\",\n",
-    "    date=f'{date}T00:00:00Z',\n",
+    "    date=f\"{date}T00:00:00Z\",\n",
     "    colorbar_caption=\"Wind Gusts (mph)\",\n",
-    "    attribution='VEDA Wind Gusts',\n",
-    "    tile_name='Wind Gusts',\n",
+    "    attribution=\"VEDA Wind Gusts\",\n",
+    "    tile_name=\"Wind Gusts\",\n",
     "    opacity=0.8,\n",
-    "    height =  \"800px\"\n",
+    "    height=\"800px\",\n",
     ")\n",
     "\n",
     "# Display the map\n",
@@ -5426,11 +5427,10 @@
    "id": "089ceb67-22bf-4f3c-96a8-50c196fff2d5",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Pull Black Marble Night Lights data from the VEDA STAC catalog and visualize.</h2>\n",
+    "# Example: Black Marble Night Lights\n",
     "\n",
-    "During extreme windstorms such as derechos, sudden drops in nighttime brightness in the Black Marble imagery reveal where power infrastructure has failed and outages have occurred, while the re-illumination of areas over subsequent days tracks the pace and extent of electrical service restoration. This makes Black Marble a powerful, near-real-time proxy for assessing societal impacts and grid resilience in the storm’s wake.\n",
-    "</div>\n"
+    "This examples pulls the NASA Black Marble Night Lights data from the VEDA STAC catalog and visualizes.\n",
+    "During extreme windstorms such as derechos, sudden drops in nighttime brightness in the Black Marble imagery reveal where power infrastructure has failed and outages have occurred, while the re-illumination of areas over subsequent days tracks the pace and extent of electrical service restoration. This makes Black Marble a powerful, near-real-time proxy for assessing societal impacts and grid resilience in the storm’s wake."
    ]
   },
   {
@@ -6354,7 +6354,7 @@
     }
    ],
    "source": [
-    "collection_id = 'nightlights-derecho'\n",
+    "collection_id = \"nightlights-derecho\"\n",
     "date = \"2022-05-10\"\n",
     "\n",
     "results = client_STAC.search(collections=[collection_id], datetime=date)\n",
@@ -6369,10 +6369,10 @@
     "# grab the dashboard render block\n",
     "dashboard_render = collection.extra_fields[\"renders\"][\"dashboard\"]\n",
     "\n",
-    "assets = dashboard_render['assets'][0]\n",
-    "(vmin, vmax), = dashboard_render[\"rescale\"]\n",
+    "assets = dashboard_render[\"assets\"][0]\n",
+    "((vmin, vmax),) = dashboard_render[\"rescale\"]\n",
     "\n",
-    "collection\n"
+    "collection"
    ]
   },
   {
@@ -6602,22 +6602,24 @@
    "source": [
     "# Use the new plot_folium_from_VEDA_STAC function\n",
     "m = putils.plot_folium_from_VEDA_STAC(\n",
-    "    tiles_url_template=tiles['tiles'][0],\n",
+    "    tiles_url_template=tiles[\"tiles\"][0],\n",
     "    center_coords=[45, -93],\n",
     "    zoom_level=8,\n",
     "    rescale=(vmin, vmax),\n",
     "    colormap_name=colormap_name,\n",
-    "    capitalize_cmap=False,  #to better match VEDA colors and matplotlib colors\n",
+    "    capitalize_cmap=False,  # to better match VEDA colors and matplotlib colors\n",
     "    layer_name=\"Black Marble Night Lights\",\n",
-    "    date=f'{date}T00:00:00Z',\n",
+    "    date=f\"{date}T00:00:00Z\",\n",
     "    colorbar_caption=\"Artificial Light\",\n",
-    "    attribution='VEDA Black Marble Night Lights',\n",
-    "    tile_name='Black Marble Night Lights',\n",
+    "    attribution=\"VEDA Black Marble Night Lights\",\n",
+    "    tile_name=\"Black Marble Night Lights\",\n",
     "    opacity=0.8,\n",
-    "    height =  \"800px\"\n",
+    "    height=\"800px\",\n",
     ")\n",
     "\n",
-    "print('Visualization of St. Paul, Minnesota where values approaching 255 indicate power outages.')\n",
+    "print(\n",
+    "    \"Visualization of St. Paul, Minnesota where values approaching 255 indicate power outages.\"\n",
+    ")\n",
     "# Display the map\n",
     "m"
    ]
@@ -6627,11 +6629,12 @@
    "id": "a00dc19a-2fb6-46ae-b315-be52a63c01af",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<h2><strong>Example:</strong> Pull Global Precipitation Measurement data through the Common Metadata Repository (CMR) STAC API.</h2>\n",
     "\n",
-    "NASA's Global Precipitation Measurement Mission (GPM) uses satellites to measure Earth's rain and snowfall for the benefit of mankind. Launched by NASA and JAXA on Feb. 27th, 2014, GPM is an international mission that sets the standard for spaceborne precipitation measurements.\n",
-    "</div>\n"
+    "# Example: Global Precipitation\n",
+    "\n",
+    "Pull NASA's Global Precipitation Measurement (GPM) data through the Common Metadata Repository (CMR) STAC API.\n",
+    "NASA's GPM uses satellites to measure Earth's rain and snowfall for the benefit of mankind. Launched by NASA and JAXA on Feb. 27th, 2014, GPM is an international mission that sets the standard for spaceborne precipitation measurements.\n",
+    "\n"
    ]
   },
   {
@@ -6641,8 +6644,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Specific for May 05, 2022 (using titiler-cmr request)\n",
-    "date = '2022-05-12'\n",
+    "# Specific for May 05, 2022 (using titiler-cmr request)\n",
+    "date = \"2022-05-12\"\n",
     "basetile_URL = \"https://staging.openveda.cloud/api/titiler-cmr/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?\"\n",
     "tile_URL = f\"datetime={date}T00%3A00%3A00.000Z%2F{date}T23%3A59%3A59.999Z&resampling=bilinear&variable=precipitation&colormap_name=gnbu&rescale=0%2C46&concept_id=C2723754864-GES_DISC&backend=xarray\"\n",
     "tilejson_url = f\"{basetile_URL}{tile_URL}\""
@@ -6833,19 +6836,17 @@
     }
    ],
    "source": [
-    "\n",
     "m = putils.plot_folium_from_VEDA_STAC(\n",
     "    tiles_url_template=tilejson_url,\n",
     "    layer_name=\"GPM Imerge Precipitation\",\n",
     "    colorbar_caption=\"mm/hr\",\n",
-    "    date = \"2022-05-12\",\n",
-    "    colormap_name = \"Blues\",\n",
-    "    capitalize_cmap=False,  #to better match VEDA colors and matplotlib colors\n",
-    "    center_coords = [46.55,-96.94],\n",
-    "    zoom_level = 5,\n",
-    "    height =  \"800px\",\n",
-    "    rescale = (0, 46)\n",
-    "\n",
+    "    date=\"2022-05-12\",\n",
+    "    colormap_name=\"Blues\",\n",
+    "    capitalize_cmap=False,  # to better match VEDA colors and matplotlib colors\n",
+    "    center_coords=[46.55, -96.94],\n",
+    "    zoom_level=5,\n",
+    "    height=\"800px\",\n",
+    "    rescale=(0, 46),\n",
     ")\n",
     "\n",
     "m"
@@ -6856,9 +6857,11 @@
    "id": "ba192aa4-6fe4-42f6-bad1-b5ded0b205f4",
    "metadata": {},
    "source": [
-    "## The economic impact reached beyond the crop fields. Many grain silos, irrigation systems, and farm buildings were also damaged or destroyed, adding to the financial burden on farmers.  See image below to identify crop types across the Midwest and the Storm Prediction Center reports across the Midwest.\n",
+    "## Economic Impact\n",
+    "The economic impact reached beyond the crop fields. Many grain silos, irrigation systems, and farm buildings were also damaged or destroyed, adding to the financial burden on farmers.  See image below to identify crop types across the Midwest and the Storm Prediction Center reports across the Midwest.\n",
     "\n",
-    "### Use the slider below to compare the USDA corn and soybean land cover for the year 2022 and all unfiltered storm reports collected by the Storm Prediction Center (SPC) on May 12, 2022. \n",
+    "### Compare Corn vs Soybean\n",
+    "Use the slider below to compare the USDA corn and soybean land cover for the year 2022 and all unfiltered storm reports collected by the Storm Prediction Center (SPC) on May 12, 2022. \n",
     "\n",
     "Image credit [USDA](https://www.nass.usda.gov/Research_and_Science/Cropland/sarsfaqs2.php) and [Storm Prediction Center](https://www.spc.noaa.gov/)."
    ]
@@ -6890,17 +6893,7 @@
     "img1_path = \"images/derecho/Derecho-Crop.jpg\"\n",
     "img2_path = \"images/derecho/Derecho-storm-reports.jpg\"\n",
     "\n",
-    "putils.create_pausable_blend_slider(img1_path, img2_path, width=800)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bc7e7ac4-f443-466b-9cfc-c58ebe6c9fa5",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<h2><strong>End of visualizations</strong>\n",
-    "</div>\n"
+    "putils.create_pausable_blend_slider(img1_path, img2_path, width=800)"
    ]
   },
   {
@@ -6908,16 +6901,15 @@
    "id": "1bab2de7-05fe-4c7e-88d1-f56f48ea92ed",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-danger\">\n",
-    "<h2><strong>Clean Up</strong>\n",
-    "</div>\n",
+    "# Clean Up (Optional)\n",
+    "\n",
     "\n",
     "Remove any **.gif** files that were created to save on storage space. Additionally, remove any **core** files that were created if the kernel crashed."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "46fcc420-3c68-481c-9223-86484eea1820",
    "metadata": {},
    "outputs": [
@@ -6932,9 +6924,6 @@
     }
    ],
    "source": [
-    "import os\n",
-    "import glob\n",
-    "\n",
     "# find all .gif files in the current directory\n",
     "for gif_path in glob.glob(\"*.gif\"):\n",
     "    try:\n",
@@ -6949,7 +6938,7 @@
     "        os.remove(core_path)\n",
     "        print(f\"Removed {core_path}\")\n",
     "    except OSError as e:\n",
-    "        print(f\"Error removing {core_path}: {e}\")\n"
+    "        print(f\"Error removing {core_path}: {e}\")"
    ]
   }
  ],

--- a/user-guide/notebooks/stories/derechos.ipynb
+++ b/user-guide/notebooks/stories/derechos.ipynb
@@ -1007,7 +1007,7 @@
    "id": "0e06456e-bfe6-4e43-ae7a-d56aba746c91",
    "metadata": {},
    "source": [
-    "## Create a animation over dates"
+    "## Create an animation over dates"
    ]
   },
   {


### PR DESCRIPTION
This is a fix for #240 
You can see in this preview how much better the side nav is now.
<img width="308" height="759" alt="image" src="https://github.com/user-attachments/assets/897f77bc-0ae6-47ae-9671-3c399a30d519" />


Reformat all the section heading to markdown instead of overriding templates with html headings. Shorten title, and move text to topic sentences. TODO: link to VEDA Story and Dataset homepages.

<!---
Thanks for making a contribution to veda-docs!
If you are updating an existing notebook feel free to delete the sections below
-->

## Description
This notebook shows ...

## What type of example is this?
_Choose one of the following and delete the rest ([read more](https://nasa-impact.github.io/veda-docs/notebooks))_

Quickstart: Accessing the Data Directly
Quickstart: Using the Raster API
Tutorial
Dataset

## Checklist
_The following checklist ensures that our notebooks are internally consistent ([read more](https://nasa-impact.github.io/veda-docs/content-curation/doc-and-notebooks))_

- [x] The first cell contains the rendering information with author and data
- [x] The notebook has a **Run this Notebook** section (with filename in link)
- [x] The notebook has an **Approach** section
- [x] All the packages that are imported in the notebooks are used within the notebook
- [x] Any complex geometries are accessed from remote storage
- [x] Each code cell comes after a markdown cell containing explantory text
- [x] All cells in the notebook book have been run in order with a fresh kernel (cell numbers should be 1, 2, 3, 4, ...)
- [x] If the example type is **Dataset** the filename is `<collection_id>.ipynb`
