### PR TITLE
RStudio S3 Access Doc

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -77,6 +77,7 @@ website:
               - user-guide/data-services/data-store.qmd
               - user-guide/data-services/data-ingestion.qmd
               - user-guide/data-services/setup-keycloak.qmd
+              - user-guide/data-services/rstudio-s3-access.qmd
               - section: user-guide/data-services/apis/index.qmd
                 contents:
                   - user-guide/data-services/apis/raster-api.qmd

--- a/user-guide/data-services/rstudio-s3-access.qmd
+++ b/user-guide/data-services/rstudio-s3-access.qmd
@@ -1,20 +1,8 @@
 ---
-"title: RStudio VEDA S3 Bucket Access\n",
-"description: Setting environment variables to access VEDA S3 buckets within RStudio\n",
-"author: Alex Mandel, Sheyenne Kirkland\n",
-"date: August 7, 2025\n",
-"execute:\n",
-"  cache: true\n",
-"  freeze: true\n",
-"format: html"
+title: RStudio VEDA S3 Bucket Access
 ---
 
-## Run This File
-You can launch this notebook in VEDA JupyterHub by clicking the link below.
-
-[Launch in VEDA JupyterHub (requires access)](https://hub.openveda.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/user-guide/notebooks/quickstarts/rstudio-bucket-access.qmd&branch=main)
-
-## Approach
+## Overview
 Users of the RStudio image in the VEDA Jupyterhub cannot access VEDA AWS buckets the same way Python Pangeo users can. This is because RStudio does not read global system environmental variables, which is where VEDA’s AWS credentials are set. In this example, we will:
 
 1. Set environment variables
@@ -30,7 +18,7 @@ Sys.setenv(AWS_WEB_IDENTITY_TOKEN_FILE="/var/run/secrets/eks.amazonaws.com/servi
 
 ## Access Data in a VEDA S3 Bucket
 
-Read necessary library
+Load package(s)
 
 ```{r}
 library(terra)

--- a/user-guide/data-services/rstudio-s3-access.qmd
+++ b/user-guide/data-services/rstudio-s3-access.qmd
@@ -1,0 +1,45 @@
+---
+"title: RStudio VEDA S3 Bucket Access\n",
+"description: Setting environment variables to access VEDA S3 buckets within RStudio\n",
+"author: Alex Mandel, Sheyenne Kirkland\n",
+"date: August 7, 2025\n",
+"execute:\n",
+"  cache: true\n",
+"  freeze: true\n",
+"format: html"
+---
+
+## Run This File
+You can launch this notebook in VEDA JupyterHub by clicking the link below.
+
+[Launch in VEDA JupyterHub (requires access)](https://hub.openveda.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/user-guide/notebooks/quickstarts/rstudio-bucket-access.qmd&branch=main)
+
+## Approach
+Users of the RStudio image in the VEDA Jupyterhub cannot access VEDA AWS buckets the same way Python Pangeo users can. This is because RStudio does not read global system environmental variables, which is where VEDA’s AWS credentials are set. In this example, we will:
+
+1. Set environment variables
+
+2. Access data in a VEDA S3 bucket
+
+## Set Environment Variables
+
+```{r}
+Sys.setenv(AWS_ROLE_ARN="arn:aws:iam::444055461661:role/nasa-veda-prod")
+Sys.setenv(AWS_WEB_IDENTITY_TOKEN_FILE="/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+```
+
+## Access Data in a VEDA S3 Bucket
+
+Read necessary library
+
+```{r}
+library(terra)
+```
+
+Open the data
+
+```{r}
+vsi_path <- '/vsis3/veda-data-store/landslides-nc-flood/NC_Flood_Extent_2024-09-29.tif'
+nc_flood <- rast(vsi_path)
+print(nc_flood)
+```


### PR DESCRIPTION
<!---
Thanks for making a contribution to veda-docs!
If you are updating an existing notebook feel free to delete the sections below
-->

## Description
This example shows how to set environment variables that are needed for VEDA S3 bucket access.

## Checklist
_The following checklist ensures that our notebooks are internally consistent ([read more](https://nasa-impact.github.io/veda-docs/content-curation/doc-and-notebooks))_

- [ ] The first cell contains the rendering information with author and data
- [ ] The notebook has a **Run this Notebook** section (with filename in link)
- [ ] The notebook has an **Approach** section
- [ ] All the packages that are imported in the notebooks are used within the notebook
- [ ] Any complex geometries are accessed from remote storage
- [ ] Each code cell comes after a markdown cell containing explantory text
- [ ] All cells in the notebook book have been run in order with a fresh kernel (cell numbers should be 1, 2, 3, 4, ...)
- [ ] If the example type is **Dataset** the filename is `<collection_id>.ipynb`
