### PR TITLE
fix: temp-r-skip

### DIFF
--- a/user-guide/data-services/rstudio-s3-access.qmd
+++ b/user-guide/data-services/rstudio-s3-access.qmd
@@ -12,7 +12,7 @@ Users of the RStudio image in the VEDA Jupyterhub cannot access VEDA AWS buckets
 
 ## Set Environment Variables
 
-```{r}
+```
 Sys.setenv(AWS_ROLE_ARN="arn:aws:iam::444055461661:role/nasa-veda-prod")
 Sys.setenv(AWS_WEB_IDENTITY_TOKEN_FILE="/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
 ```
@@ -21,13 +21,13 @@ Sys.setenv(AWS_WEB_IDENTITY_TOKEN_FILE="/var/run/secrets/eks.amazonaws.com/servi
 
 Load package(s)
 
-```{r}
+```
 library(terra)
 ```
 
 Open the data
 
-```{r}
+```
 vsi_path <- '/vsis3/veda-data-store/landslides-nc-flood/NC_Flood_Extent_2024-09-29.tif'
 nc_flood <- rast(vsi_path)
 print(nc_flood)


### PR DESCRIPTION
We realized {r} blocks require Rscript and R to work. Skipping for now to unblock other builds
